### PR TITLE
Removing the defunct script_path variable.

### DIFF
--- a/config.py
+++ b/config.py
@@ -32,12 +32,10 @@ global gid
 # repo - the rep that is hosting the build
 # branch - the branch that we are using. useful to change this if developing /
 # testing
-# script_path -  the path that the script is executed from
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
 branch = "master"
-script_path = os.path.realpath(__file__)
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts


### PR DESCRIPTION
The `script_path` variable was a holdover from a previous design concept for this script and it was getting in the way of our ability to `curl` this script to a machine without writing the script to a file.