### PR TITLE
Feature: Operating System Check / Exit Codes for Shell Scripts

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "master"
+branch = "feat-oscheck"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "f17bf69a548bb427824f071fce958905c35988552a086ebc87889bf6dfc70007"
+manifest_hash = "66972805cc7e101c257ce7536bb3350a3c6de6768acad3e9426cbe14c9ff5b20"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -125,7 +125,7 @@ def script_exec(script):
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for line in iter(pipes.stdout.readline, b''):
         print("*** " + line.rstrip())
-
+    print pipes.returncode
 
 # the dmg installer is by far the most complicated function, because DMGs are
 # more complicated than a .app inside we take the appropriate action. we also

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "feat-oscheck"
+branch = "master"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts

--- a/config.py
+++ b/config.py
@@ -125,7 +125,10 @@ def script_exec(script):
         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
     for line in iter(pipes.stdout.readline, b''):
         print("*** " + line.rstrip())
-    print pipes.returncode
+    pipes.communicate()
+    if pipes.returncode == 1:
+        exit(1)
+
 
 # the dmg installer is by far the most complicated function, because DMGs are
 # more complicated than a .app inside we take the appropriate action. we also

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,16 @@
 {
     "packages": [
         {
+            "item": "MacOS Version Check", 
+            "version": "", 
+            "url": "repo/macos-versioncheck.sh", 
+            "filename": "", 
+            "dmg-installer": "", 
+            "dmg-advanced": "", 
+            "hash": "a2956c5c20dc410da766572aebcc38c2121ccf596cd24b1915dd6cd46f6f17b1", 
+            "type": "shell"
+        }, 
+        {
             "item": "Crashplan", 
             "version": "4.5.2", 
             "url": "https://download.code42.com/installs/mac/install/CrashPlanPROe/CrashPlanPROe_${version}_Mac.dmg", 

--- a/repo/macos-versioncheck.sh
+++ b/repo/macos-versioncheck.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# this script checks for a minimum OS version and is intended to halt the build
+# if the machine does not meet that minimum version
+
+# expected_os - OS family version
+# expected_major - expectedmajor version (13 = High Sierra, etc)
+# expected_minor - expected minor version
+
+expected_os="10"
+expected_major="13"
+expected_minor="1"
+
+os_version=$(sw_vers -productVersion | awk -F '.' '{print $1}')
+major_version=$(sw_vers -productVersion | awk -F '.' '{print $2}')
+minor_version=$(sw_vers -productVersion | awk -F '.' '{print $3}')
+
+if ! [[ "$os_version" -ge "$expected_os" && "$major_version" -ge "$expected_major" && "$minor_version" -ge "$expected_minor" ]]; then
+	echo "UPGRADE REQUIRED: You are running MacOS ${os_version}.${major_version}.${minor_version}"
+	echo "We are expecting: ${expected_os}.${expected_major}.${expected_minor}"
+	echo "The build will halt, please update MacOS via the App Store and try again."
+	exit 1
+else
+	echo "You are running MacOS ${os_version}.${major_version}.${minor_version}, which is the version we expect"
+	exit 0
+fi


### PR DESCRIPTION
Dinobuildr will now read exit codes when executing shell scripts and will terminate the build if the exit code 1 is returned by the script. This is useful for error handling and should be expanded in the future to accept other error codes.

We've also added a minimum OS check, to make sure that the build is being executed on the minimum version of the operating system. The build will fail if the minimum version is not present. 