### PR TITLE
Bug: Crashplan Postinstall Script would fail occasionally

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "master"
+branch = "bug-crashplan-quit"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "69123b8e427390dc327e760377a9b7d2876eb287f18381e2dd1ee2ff53065530"
+manifest_hash = "7cf1f3f378b78ff9dfdc3b0b3906dd9b17b1b9e11acfc5a2bfb59314438d2a48"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "bug-crashplan-quit"
+branch = "master"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
             "filename": "", 
             "dmg-installer": "", 
             "dmg-advanced": "", 
-            "hash": "cb0236f04b6343326731b4e38b7d6ac2539e491874e518d2f9f1ef202efe54e9", 
+            "hash": "3b8711139c03f203330c55db8d55a4311d46a0df6addc28111a9ab7d4578be72", 
             "type": "shell"
         }, 
         {

--- a/repo/crashplan-postinstall.sh
+++ b/repo/crashplan-postinstall.sh
@@ -11,3 +11,4 @@
 
 echo "Waiting for Crashplan to launch and then quitting it..."
 killall -TERM CrashPlan 
+exit 0


### PR DESCRIPTION
On certain machines, the Crashplan postinstall script would complain that it couldn't find the Crashplan process and the build would fail. 

```
Executing: Crashplan PostInstall
*** Waiting for Crashplan to launch and then quitting it...
*** No matching processes were found
```

As a hack, we put an `exit 0` in the script so the whole build wouldn't fail in this case. 
