### PR TITLE
Bug: Roll back macOS version check to 10.13.0

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "master"
+branch = "bug-rollbackoscheck"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "8d89864e157448c695a54e3b28051b27761a2c12a62bb55ad37f6204fd6a6a97"
+manifest_hash = "f918882a8341310654e07cdbf4ea8ade613191b356ebc7b30deecf034443d6a6"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "f918882a8341310654e07cdbf4ea8ade613191b356ebc7b30deecf034443d6a6"
+manifest_hash = "2ae6f11340235fbafa4267518096de1ad8bd2a5bcd04b745843a9218dbe3e9b2"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "bug-rollbackoscheck"
+branch = "master"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
             "filename": "", 
             "dmg-installer": "", 
             "dmg-advanced": "", 
-            "hash": "abc40598c5d05c57071dbcdbae55831a691c0009b56101917fbe75b429f0f793", 
+            "hash": "b8733abd622eeb060cdcb911e3f1c09ccccf86e1f198961ac63ee35bc282715f", 
             "type": "shell"
         }, 
         {

--- a/repo/macos-versioncheck.sh
+++ b/repo/macos-versioncheck.sh
@@ -13,7 +13,7 @@
 
 expected_os="10"
 expected_major="13"
-expected_minor="1"
+expected_minor="0"
 
 os_version=$(sw_vers -productVersion | awk -F '.' '{print $1}')
 major_version=$(sw_vers -productVersion | awk -F '.' '{print $2}')
@@ -25,6 +25,6 @@ if ! [[ "$os_version" -ge "$expected_os" && "$major_version" -ge "$expected_majo
     echo "The build will halt, please update macOS via the App Store and try again."
     exit 1
 else
-    echo "You are running macOS ${os_version}.${major_version}.${minor_version}, which is the version we expect!"
+    echo "You are running macOS ${os_version}.${major_version}.${minor_version}, which meets the minimum requirements."
     exit 0
 fi


### PR DESCRIPTION
Set the minimum accepted macOS version to 10.13.0, since our update script will push out minor versions and we only want to halt the build if it's running on a machine that isn't on High Sierra. 