### PR TITLE
Feature: Set "Hostname"

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "master"
+branch = "feat-sethostname"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "f8ac58b3282ac16aa5d714b9059d1ad3634f69093e2b46c86a01ca63c85cc9e3"
+manifest_hash = "b20971d55bfd652c3b60ae2ddd05ea55b70efb163b22a1a38961f3b45e2e2b8c"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "master"
+branch = "feat-sethostname"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts
@@ -58,7 +58,7 @@ gid = grp.getgrnam("staff").gr_gid
 lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/manifest.json" % (org, repo, branch)
-manifest_hash = "b20971d55bfd652c3b60ae2ddd05ea55b70efb163b22a1a38961f3b45e2e2b8c"
+manifest_hash = "f11aa885e11563fbb51110d51a4aca1a4be199251b2a9d9c8972c6789ae00a96"
 manifest_file = "%s/manifest.json" % local_dir
 
 # check to see if user ran with sudo , since it's required

--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ global gid
 local_dir = "/var/tmp/dinobuildr"
 org = "mozilla"
 repo = "dinobuildr"
-branch = "feat-sethostname"
+branch = "master"
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
             "filename": "", 
             "dmg-installer": "", 
             "dmg-advanced": "", 
-            "hash": "e3877230971e81a17dbdae39d14cd5c563f2b88b7411297bf9747c539d7141f9", 
+            "hash": "26f27eff72ee2d335bd2948291a1b4173c63186fd2504dc08be9b94755abd325", 
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,16 @@
             "type": "shell"
         }, 
         {
+            "item": "Configure ComputerName", 
+            "version": "", 
+            "url": "repo/set-computername.sh", 
+            "filename": "", 
+            "dmg-installer": "", 
+            "dmg-advanced": "", 
+            "hash": "e3877230971e81a17dbdae39d14cd5c563f2b88b7411297bf9747c539d7141f9", 
+            "type": "shell"
+        },
+        {
             "item": "Install Crashplan", 
             "version": "4.5.2", 
             "url": "https://download.code42.com/installs/mac/install/CrashPlanPROe/CrashPlanPROe_${version}_Mac.dmg", 

--- a/repo/set-computername.sh
+++ b/repo/set-computername.sh
@@ -26,4 +26,3 @@ echo "Setting LocalHostName and ComputerName to ${hostname}"
 
 scutil --set LocalHostName $hostname
 scutil --set ComputerName $hostname
-dscacheutil -flushcache

--- a/repo/set-computername.sh
+++ b/repo/set-computername.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script sets the LocalHostName and the ComputerName on a machine using
+# the following naming convention: [username]-[last 6 digits of the serial
+# number]. We also make sure the we don't use any capital letters because
+# Tristan hates them. 
+
+lastSNdigits=$(system_profiler SPHardwareDataType |
+               grep 'Serial Number (system)' | 
+               awk '{print $NF}' | 
+               tail -c 7)
+user=`python -c '
+from SystemConfiguration import SCDynamicStoreCopyConsoleUser;
+import sys;
+username = (SCDynamicStoreCopyConsoleUser(None, None, None) or [None])[0];
+username = [username,""][username in [u"loginwindow", None, u""]];
+sys.stdout.write(username + "\n");'`
+hostname="${user}-"${lastSNdigits}""
+hostname=$(echo $hostname | tr '[:upper:]' '[:lower:]')
+
+echo "Setting LocalHostName and ComputerName to ${hostname}"
+
+scutil --set LocalHostName $hostname
+scutil --set ComputerName $hostname
+dscacheutil -flushcache


### PR DESCRIPTION
Per #51 - Hostname is a bit of a misnomer, since we're not actually setting the hostname anywhere. A more accurate feature description would be "Set ComputerName and LocalHostName" but that's annoying. 

We added the set-computername.sh script early in the build so that software like Crashplan will have access to the correct hostname, in case it matters. 

Build has been tested in a development branch, ready to push to master. 