### PR TITLE
Bug: Add missing newlines after shell script executions

### DIFF
--- a/config.py
+++ b/config.py
@@ -277,6 +277,7 @@ for item in data['packages']:
         perms = os.stat(local_path)
         os.chmod(local_path, perms.st_mode | stat.S_IEXEC)
         script_exec(local_path)
+        print "\r"
 
     if item['type'] == "dmg":
         # TODO: consisitency: there should be URL checks everywhere or do this

--- a/config.py
+++ b/config.py
@@ -249,6 +249,7 @@ print "\n***** DINOBUILDR IS BUILDING. RAWR. *****\n"
 # copying the installer or installing a pkg.
 with open(manifest_file, 'r') as manifest_data:
     data = json.load(manifest_data)
+
 for item in data['packages']:
     if item['filename'] != "":
         file_name = item['filename']

--- a/config.py
+++ b/config.py
@@ -230,10 +230,13 @@ if not os.path.exists(local_dir):
     os.makedirs(local_dir)
 
 # download the manifest.json file.
+print "\nDownloading the manifest file and hash-checking it.\n"
 downloader(manifest_url, manifest_file)
 
 # check the hash of the incoming manifest file and bail if the hash doesn't match.
 hash_file(manifest_file, manifest_hash)
+
+print "\n***** DINOBUILDR IS BUILDING. RAWR. *****\n"
 
 # we read the manifest file and examine each object in it. if the object is a
 # .pkg file, then we assemble the download url of the pointer, read the pointer
@@ -246,7 +249,6 @@ hash_file(manifest_file, manifest_hash)
 # copying the installer or installing a pkg.
 with open(manifest_file, 'r') as manifest_data:
     data = json.load(manifest_data)
-
 for item in data['packages']:
     if item['filename'] != "":
         file_name = item['filename']


### PR DESCRIPTION
Shell scripts were missing a newline after executing, which was causing the script output to be REAL ugly. Also added a little messaging around script start and the manifest hash check to make it make a little more sense. 

<img width="736" alt="image" src="https://user-images.githubusercontent.com/5789441/34187519-a0582726-e4e6-11e7-8ac3-fbd0c1258065.png">
