### PR TITLE
Arbitrary Branch Support

### DIFF
--- a/config.py
+++ b/config.py
@@ -252,7 +252,7 @@ downloader(manifest_url, manifest_file)
 hash_file(manifest_file, manifest_hash)
 
 print "\n***** DINOBUILDR IS BUILDING. RAWR. *****\n"
-print "Using building against the [%s] branch\n" % branch
+print "Building against the [%s] branch\n" % branch
 # we read the manifest file and examine each object in it. if the object is a
 # .pkg file, then we assemble the download url of the pointer, read the pointer
 # and request the file from LFS. if the file we get has a hash that matches

--- a/config.py
+++ b/config.py
@@ -252,7 +252,7 @@ downloader(manifest_url, manifest_file)
 hash_file(manifest_file, manifest_hash)
 
 print "\n***** DINOBUILDR IS BUILDING. RAWR. *****\n"
-
+print "Using building against the [%s] branch\n" % branch
 # we read the manifest file and examine each object in it. if the object is a
 # .pkg file, then we assemble the download url of the pointer, read the pointer
 # and request the file from LFS. if the file we get has a hash that matches

--- a/dinobuildr.sh
+++ b/dinobuildr.sh
@@ -23,7 +23,7 @@ curl_status=$?
 # script can fail in a predictable way.
 
 if [ $curl_status -eq 0 ]; then
-    python -c "$build_script" "$branch"
+    python -c "$build_script" -b "$branch"
 else 
     echo "********************************************************************"
     echo "Uh oh, unable to download Dinobuildr from Github."


### PR DESCRIPTION
Let's try this again (since I messed it up last time) (see #90 and #91)

Previously, running dinobuildr against a specific branch required changing the branch variable in config.py, which was annoying. This PR adds support for "arbitrary" branches within the repo and org config.py is configured to use.

This is particularly useful in testing, since a dinobuildr can be used to test arbitrary branches without needing to pull the branch down, change the variable and push back to the development branch (then undo all those changes when the testing is complete).