### PR TITLE
Feat disable bluetooth assistance

### DIFF
--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -121,6 +121,16 @@
             "type": "shell"
         },
         {
+            "item": "Disable Bluetooth Setup Assistant",
+            "version": "",
+            "url": "repo/corsica/disable-bluetooth-setup-assistant.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "7b92fd58cd018391fd78e77cac79f2924bc156a862d2980b4ea2505e585d420a",
+            "type": "shell"
+        },
+        {
             "item": "Skip iCloud Setup Assistant",
             "version": "",
             "url": "repo/corsica/skip-icloud-setup.mobileconfig",

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -97,7 +97,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "a48c45bce6afb352bdc1eb80232d0b24bf4119890318b874fc9c61f4b81adab7",
+            "hash": "a3bd389fac7d2c940e33e62b274a82209714426ba8a46ac0900ffe847024d235",
             "type": "shell"
         },
         {

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "f471bf3980729bf8529fdb8e9646d8fb5cc9f32a7b066c7642386c223751516e"
+ambient_manifest_hash = "7789704ff4348ee46311132fabd272d0e6e3e9859341c4e2184f13415325cf83"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "9c70382c40f271bddb4136a9e2d7add0f22451e0c8fe87ccd10ce91d9bc0f367"
+ambient_manifest_hash = "f471bf3980729bf8529fdb8e9646d8fb5cc9f32a7b066c7642386c223751516e"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/repo/corsica/disable-bluetooth-setup-assistant.sh
+++ b/repo/corsica/disable-bluetooth-setup-assistant.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script disables Bluetooth Setup Assistant at startup if no
+# keyboard, mouse, or trackpad is detected.
+
+defaults write /Library/Preferences/com.apple.Bluetooth.plist BluetoothAutoSeekKeyboard 0
+
+defaults write /Library/Preferences/com.apple.Bluetooth.plist BluetoothAutoSeekPointingDevice 0

--- a/repo/corsica/launch-firefox.sh
+++ b/repo/corsica/launch-firefox.sh
@@ -58,6 +58,7 @@ cat > /Users/Shared/launch-firefox.plist <<- "EOF"
         <string>-a</string>
 	<string>/Applications/Firefox.app</string>
 	<string>--args</string>
+	<string>--foreground</string>
 	<string>--profile</string>
 	<string>/Users/Shared/corsica-profile/</string>
     </array>


### PR DESCRIPTION
Disables Bluetooth Setup Assistant at startup if no keyboard, mouse, or trackpad is detected.