### PR TITLE
Keep Firefox fullscreen after shutdown or reboot

### DIFF
--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -97,7 +97,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "a3bd389fac7d2c940e33e62b274a82209714426ba8a46ac0900ffe847024d235",
+            "hash": "ad5fe3c7092fbf420098037f728a7626aed362723e79fd23aafa1438fb986a3d",
             "type": "shell"
         },
         {

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "7789704ff4348ee46311132fabd272d0e6e3e9859341c4e2184f13415325cf83"
+ambient_manifest_hash = "c7d84f21277521d76e4125ff752be1682be01a081f585edf6dd82050ca0b17c8"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/repo/corsica/launch-firefox.sh
+++ b/repo/corsica/launch-firefox.sh
@@ -4,9 +4,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This script creates a AppleScript and LaunchAgent. The LaunchAgent 
-# launches the AppleScript under the corsica user at login and the 
-# AppleScript launches Firefox in fullscreen mode.
+# This script creates a LaunchAgent and LaunchDaemon. The LaunchAgent 
+# launches Firefox in fullscreen mode under the corsica user at login. 
+# The LaunchDaemon prevents Firefox from automatically relaunching
+# after a reboot, shutdown, or power outage. The LaunchDaemon also
+# clears the previous Firefox session before Firefox launches again.
 
 cat > /Users/Shared/move-launch-firefox.sh <<- "EOF"
 #!/bin/bash
@@ -61,6 +63,26 @@ cat > /Users/Shared/launch-firefox.plist <<- "EOF"
 	<string>--foreground</string>
 	<string>--profile</string>
 	<string>/Users/Shared/corsica-profile/</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+cat > /Library/LaunchDaemons/reset-firefox-session.plist <<- "EOF"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>reset-firefox-session</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>bash</string>
+        <string>-c</string>
+        <string>rm -rf /Users/Shared/corsica-profile/sessionstore*;
+        rm -rf /Users/corsica/Library/Preferences/ByHost/com.apple.loginwindow.*</string>
     </array>
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
Added LaunchDaemon to clear the Firefox sessionstore and disable automatic open app restores after a reboot or shutdown