### PR TITLE
Feature - Corsica Autoupdate

### DIFF
--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -123,7 +123,7 @@
         {
             "item": "Enable automatic updates",
             "version": "",
-            "url": "repo/auto-update.sh",
+            "url": "repo/corsica/auto-update.sh",
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -127,7 +127,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "7ed0e6288ab0f260d0ec3f3cb6854ebd6320f24d42c29832a54f78a547bc54c3",
+            "hash": "bf1ffd1fe06d3b88f3c33a135df800847c5d93c46e5d963fef992035900e64dd",
             "type": "shell"
         },
         {

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -169,6 +169,16 @@
             "dmg-advanced": "",
             "hash": "9fc4d33f0bcd4eaf645baba7b55832e0c5fff61892e729c5e8b282a326c15f84",
             "type": "mobileconfig"
+        },
+        {
+            "item": "Update macOS",
+            "version": "",
+            "url": "repo/update-macos.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "fd2426aedee44e6af72dcca2953a885e9b7486982fd85ad30f328c8384b545e9",
+            "type": "shell"
         }
     ]
 }

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -123,11 +123,11 @@
         {
             "item": "Enable automatic updates",
             "version": "",
-            "url": "repo/app-store-updates.sh",
+            "url": "repo/auto-update.sh",
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "5de09057abdbc563d0cc4f802ab3138d901dd1ba711f7ddcf6de99299a54affb",
+            "hash": "7ed0e6288ab0f260d0ec3f3cb6854ebd6320f24d42c29832a54f78a547bc54c3",
             "type": "shell"
         },
         {
@@ -169,16 +169,6 @@
             "dmg-advanced": "",
             "hash": "9fc4d33f0bcd4eaf645baba7b55832e0c5fff61892e729c5e8b282a326c15f84",
             "type": "mobileconfig"
-        },
-        {
-            "item": "Update macOS",
-            "version": "",
-            "url": "repo/update-macos.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "fd2426aedee44e6af72dcca2953a885e9b7486982fd85ad30f328c8384b545e9",
-            "type": "shell"
         }
     ]
 }

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -127,7 +127,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "bf1ffd1fe06d3b88f3c33a135df800847c5d93c46e5d963fef992035900e64dd",
+            "hash": "37dc6fb95db6620b3108e44e5efa3558cbb2b1c5c9b74de9b5f45a528f729daf",
             "type": "shell"
         },
         {

--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -127,7 +127,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "37dc6fb95db6620b3108e44e5efa3558cbb2b1c5c9b74de9b5f45a528f729daf",
+            "hash": "5c2beeb3f17983d42ec1f0525791847745c993b1fb1bc0a5098cdd459120b9c4",
             "type": "shell"
         },
         {

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
+default_manifest_hash = "411c03a12662be23831210c210ee65bc3f7e9bbae12c42d40188cb677e89a7d4"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "10dc2c81bd3a104cb08de1a500fd7cd03cfe3ea0f2dcb5bd6e6b7c318042a6b6"
+ambient_manifest_hash = "c13aa07ee554eadb26bee81667ba0a2b00fdf349aa58f1cb74dd1731d6a661e2"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "a6d094f81899483194fae05e45d351743825435f87e94eb567a26b386c8f3759"
+ambient_manifest_hash = "b1eeb90e6eb6201c75abf8ae1df35e1c7844cf75c14225f1c6d50f52df1bf456"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "b1eeb90e6eb6201c75abf8ae1df35e1c7844cf75c14225f1c6d50f52df1bf456"
+ambient_manifest_hash = "10dc2c81bd3a104cb08de1a500fd7cd03cfe3ea0f2dcb5bd6e6b7c318042a6b6"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "1e1a2aea9e3089dc99e533674e1d50c60dfc247f8605adb35b45f742b844c742"
+ambient_manifest_hash = "0c56d8116ba64ebf98016e26be572bbf8429794570d6ac9f864f4e5ada6759cd"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "0c56d8116ba64ebf98016e26be572bbf8429794570d6ac9f864f4e5ada6759cd"
+ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "61f6fc9b2bf9f2711c9eb4e2e9032dc825534fba83b02db0f1fcda09fb3fbdb5"
-ambient_manifest_hash = "c13aa07ee554eadb26bee81667ba0a2b00fdf349aa58f1cb74dd1731d6a661e2"
+ambient_manifest_hash = "1e1a2aea9e3089dc99e533674e1d50c60dfc247f8605adb35b45f742b844c742"
 manifest_hash = default_manifest_hash
 if manifest == "ambient_manifest.json":
     manifest_hash = ambient_manifest_hash

--- a/manifest.json
+++ b/manifest.json
@@ -62,12 +62,12 @@
         },
         {
             "item": "Install Firefox",
-            "version": "60.0",
+            "version": "60.0.2",
             "url": "https://download.mozilla.org/?product=firefox-${version}-SSL&os=osx&lang=en-US",
             "filename": "firefox.dmg",
             "dmg-installer": "Firefox.app",
             "dmg-advanced": "",
-            "hash": "1e9145ee978ebd8d1712f48aae4cbe016ebe68254141b978061e240474bcb2ea",
+            "hash": "c229cf2135a1380dfcd1439c15ebb7a36df6b3055dc2e07da584404a6414d732",
             "type": "dmg"
         },
         {

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -12,7 +12,7 @@ cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
         <string>bash</string>
         <string>-c</string>
         <string>softwareupdate -ia;
-        osascript -e 'tell app "System Events" to restart'</string>
+        shutdown -r now</string>
     </array>
     <key>StartCalendarInterval</key>
     <dict>

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>update-firefox-macos</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>bash</string>
+        <string>-c</string>
+        <string>softwareupdate -ia;
+        osascript -e 'tell app "System Events" to restart'</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>00</integer>
+    </dict>
+</dict>
+</plist>
+EOF
+
+launchctl load /Library/LaunchDaemons/update-ff-macos.plist

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -1,28 +1,70 @@
 #!/bin/bash
 
-cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>update-firefox-macos</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>bash</string>
-        <string>-c</string>
-        <string>softwareupdate -ia;
-        shutdown -r now</string>
-    </array>
-    <key>StartCalendarInterval</key>
-    <dict>
-        <key>Hour</key>
-        <integer>3</integer>
-        <key>Minute</key>
-        <integer>00</integer>
-    </dict>
-</dict>
-</plist>
-EOF
+cat > /usr/local/auto-update-routine.sh <<- "EOF"
+	#!/bin/bash
+	if [ "$(curl https://raw.githubusercontent.com/luciusbono/informant/master/informant.txt)" = "greenlight" ]; then
+	    softwareupdate -ia
+	fi
 
+	shutdown -r now
+	EOF
+
+chmod +x /usr/local/auto-update-routine.sh
+
+if [ "$1" = "canary" ]; then
+	cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
+		<?xml version="1.0" encoding="UTF-8"?>
+		<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+		<plist version="1.0">
+		<dict>
+		    <key>Label</key>
+		    <string>update-firefox-macos</string>
+		    <key>Program</key>
+		    <string>/usr/local/auto-update-routine.sh</string>
+		    <key>StartCalendarInterval</key>
+		    <dict>
+		        <key>Hour</key>
+		        <integer>3</integer>
+		        <key>Minute</key>
+		        <integer>00</integer>
+		    </dict>
+		</dict>
+		</plist>
+		EOF
+
+else
+	cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
+		<?xml version="1.0" encoding="UTF-8"?>
+		<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+		<plist version="1.0">
+		<dict>
+		    <key>Label</key>
+		    <string>update-firefox-macos</string>
+		    <key>Program</key>
+		    <string>/usr/local/auto-update-routine.sh</string>
+		    <key>StartCalendarInterval</key>
+		    <array>
+		        <dict>
+		            <key>Day</key>
+		            <integer>1</integer>
+		            <key>Hour</key>
+		            <integer>3</integer>
+		            <key>Minute</key>
+		            <integer>00</integer>
+		        </dict>
+		        <dict>
+		            <key>Day</key>
+		            <integer>15</integer>
+		            <key>Hour</key>
+		            <integer>3</integer>
+		            <key>Minute</key>
+		            <integer>00</integer>
+		        </dict>
+		    </array>
+		</dict>
+		</plist>
+		EOF
+fi
+
+launchctl unload /Library/LaunchDaemons/update-ff-macos.plist
 launchctl load /Library/LaunchDaemons/update-ff-macos.plist

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -7,64 +7,63 @@ cat > /usr/local/auto-update-routine.sh <<- "EOF"
 	fi
 
 	shutdown -r now
-	EOF
+	
+	if [ "$1" = "canary" ]; then
+		cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF2"
+			<?xml version="1.0" encoding="UTF-8"?>
+			<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+			<plist version="1.0">
+			<dict>
+			    <key>Label</key>
+			    <string>update-firefox-macos</string>
+			    <key>Program</key>
+			    <string>/usr/local/auto-update-routine.sh</string>
+			    <key>StartCalendarInterval</key>
+			    <dict>
+			        <key>Hour</key>
+			        <integer>3</integer>
+			        <key>Minute</key>
+			        <integer>00</integer>
+			    </dict>
+			</dict>
+			</plist>
+			EOF2
+	fi
+EOF
 
 chmod +x /usr/local/auto-update-routine.sh
 
-if [ "$1" = "canary" ]; then
-	cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
-		<?xml version="1.0" encoding="UTF-8"?>
-		<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-		<plist version="1.0">
-		<dict>
-		    <key>Label</key>
-		    <string>update-firefox-macos</string>
-		    <key>Program</key>
-		    <string>/usr/local/auto-update-routine.sh</string>
-		    <key>StartCalendarInterval</key>
-		    <dict>
-		        <key>Hour</key>
-		        <integer>3</integer>
-		        <key>Minute</key>
-		        <integer>00</integer>
-		    </dict>
-		</dict>
-		</plist>
-		EOF
-
-else
-	cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
-		<?xml version="1.0" encoding="UTF-8"?>
-		<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-		<plist version="1.0">
-		<dict>
-		    <key>Label</key>
-		    <string>update-firefox-macos</string>
-		    <key>Program</key>
-		    <string>/usr/local/auto-update-routine.sh</string>
-		    <key>StartCalendarInterval</key>
-		    <array>
-		        <dict>
-		            <key>Day</key>
-		            <integer>1</integer>
-		            <key>Hour</key>
-		            <integer>3</integer>
-		            <key>Minute</key>
-		            <integer>00</integer>
-		        </dict>
-		        <dict>
-		            <key>Day</key>
-		            <integer>15</integer>
-		            <key>Hour</key>
-		            <integer>3</integer>
-		            <key>Minute</key>
-		            <integer>00</integer>
-		        </dict>
-		    </array>
-		</dict>
-		</plist>
-		EOF
-fi
+cat > /Library/LaunchDaemons/update-ff-macos.plist <<- "EOF"
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>update-firefox-macos</string>
+    <key>Program</key>
+    <string>/usr/local/auto-update-routine.sh</string>
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Day</key>
+            <integer>1</integer>
+            <key>Hour</key>
+            <integer>3</integer>
+            <key>Minute</key>
+            <integer>00</integer>
+        </dict>
+        <dict>
+            <key>Day</key>
+            <integer>15</integer>
+            <key>Hour</key>
+            <integer>3</integer>
+            <key>Minute</key>
+            <integer>00</integer>
+        </dict>
+    </array>
+</dict>
+</plist>
+EOF
 
 launchctl unload /Library/LaunchDaemons/update-ff-macos.plist
 launchctl load /Library/LaunchDaemons/update-ff-macos.plist

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script creates a LaunchDaemon / script pair that will check 
+# for updates on a schedule and reboot the machine. 
+# It has a canary service called Informant that will interrupt the
+# updater if certain conditions are met. 
+
 cat > /usr/local/auto-update-routine.sh <<- "EOF"
 	#!/bin/bash
 	if [ "$(curl https://raw.githubusercontent.com/mozilla-it/informant/master/informant.txt)" = "greenlight" ]; then

--- a/repo/corsica/auto-update.sh
+++ b/repo/corsica/auto-update.sh
@@ -2,7 +2,7 @@
 
 cat > /usr/local/auto-update-routine.sh <<- "EOF"
 	#!/bin/bash
-	if [ "$(curl https://raw.githubusercontent.com/luciusbono/informant/master/informant.txt)" = "greenlight" ]; then
+	if [ "$(curl https://raw.githubusercontent.com/mozilla-it/informant/master/informant.txt)" = "greenlight" ]; then
 	    softwareupdate -ia
 	fi
 


### PR DESCRIPTION
This feature allows the corsica displays to aggressively autoupdate. They will check Apple for OS updates on the 1st and 15th of every month at 3am local time, and will reboot whether there are updates or not. Firefox is set to autoupdate on launch, so any Firefox updates will be installed at that time.

Devices can be put into a "canary" mode to check for updates every night at 3am. These devices should get updates before the rest of the fleet, so if they break we can interrupt the update process on the rest of our fleet with our Informant service.