### PR TITLE
Mojave Support

### DIFF
--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "098fe518705cb5bf4287319dae7aff87e26397ec1c966d0baff77377a7a81c93"
+default_manifest_hash = "e4543f76de2aaf0b52cf1953f0f90cc8022a29931e8a9bc32d68d3bbd9a75fa5"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "31093f8249defcfd864708b022787e785acaac378827e271921862d2df072557"
+default_manifest_hash = "5cbb5aa81d963d173c3326d8a088d6cb0e8b4746da57eb087b4422af7d6815d6"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -320,13 +320,14 @@ for item in data['packages']:
 
     if item['type'] == "dmg":
         # TODO: consisitency: there should be URL checks everywhere or do this
+        # TODO: dmg-installer / dmg-advanced are not being checked to allow
+        # for functionality that should be in a downloader function
         # in the manifest generator
         if item['url'] == '':
             print "No URL specified for %s" % item['item']
             break
         if item['dmg-installer'] == '' and item['dmg-advanced'] == '':
-            print "No installer or install command specified for %s" % item['item']
-            break
+            print "No installer or install command specified for %s. Assuming this is download only." % item['item']
         dl_url = item['url'].replace('${version}', item['version'])
         print "Downloading:", item['item']
         downloader(dl_url, local_path)

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "5aa85c3b35640385bbcf86c6282c811e2539ecd7047ebedbb81e152122378d49"
+default_manifest_hash = "098fe518705cb5bf4287319dae7aff87e26397ec1c966d0baff77377a7a81c93"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -326,14 +326,16 @@ for item in data['packages']:
         if item['url'] == '':
             print "No URL specified for %s" % item['item']
             break
-        if item['dmg-installer'] == '' and item['dmg-advanced'] == '':
-            print "No installer or install command specified for %s. Assuming this is download only." % item['item']
         dl_url = item['url'].replace('${version}', item['version'])
         print "Downloading:", item['item']
         downloader(dl_url, local_path)
         hash_file(local_path, item['hash'])
-        print local_path
-        print item['dmg-installer']
+        if item['dmg-installer'] != '':
+            print "Installing:", item['dmg-installer']
+        if item['dmg-advanced'] != '':
+            print "Getting fancy and executing:", item['dmg-advanced']
+        if item['dmg-installer'] == '' and item['dmg-advanced'] == '':   
+            print "No installer or install command specified for %s. Assuming this is download only." % item['item']
         if item['dmg-installer'] != '':
             dmg_install(local_path, item['dmg-installer'])
         if item['dmg-advanced'] != '':
@@ -349,6 +351,16 @@ for item in data['packages']:
         lfsfile_url = get_lfs_url(json_data, lfs_url)
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
+        hash_file(local_path, item['hash'])
+        print "\r"
+
+    if item['type'] == "file":
+        if item['url'] == '':
+            print "No URL specified for %s" % item['item']
+            break
+        dl_url = raw_url + item['url']
+        print "Downloading:", item['item']
+        downloader(dl_url, local_path)
         hash_file(local_path, item['hash'])
         print "\r"
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "411c03a12662be23831210c210ee65bc3f7e9bbae12c42d40188cb677e89a7d4"
+default_manifest_hash = "b6478ab849e23cf9ba1ce8d5c6c9f434712ecf9b258060d6a6140165000c884a"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "7361f85121966fe2e099d634e7a030eac0f13fc67a9dabe720cf9d9290bb8f5b"
+default_manifest_hash = "31093f8249defcfd864708b022787e785acaac378827e271921862d2df072557"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "b6478ab849e23cf9ba1ce8d5c6c9f434712ecf9b258060d6a6140165000c884a"
+default_manifest_hash = "7361f85121966fe2e099d634e7a030eac0f13fc67a9dabe720cf9d9290bb8f5b"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "5cbb5aa81d963d173c3326d8a088d6cb0e8b4746da57eb087b4422af7d6815d6"
+default_manifest_hash = "5aa85c3b35640385bbcf86c6282c811e2539ecd7047ebedbb81e152122378d49"
 ambient_manifest_hash = "7f77147b246c1e56d8c635b217f6de5eb21964999b15847b45b2a3a6eafb77e5"
 manifest_hash = default_manifest_hash
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "777ec350c6b7dd3516ff97364fffaa5691337ed885f7e5f5fc582489d1e78074",
+            "hash": "7c6144fbeb20361d33d65dc87cfa93419f6e7ae5fbaab6299bd3cf43c6581f8e",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "7c6144fbeb20361d33d65dc87cfa93419f6e7ae5fbaab6299bd3cf43c6581f8e",
+            "hash": "777ec350c6b7dd3516ff97364fffaa5691337ed885f7e5f5fc582489d1e78074",
             "type": "shell"
         },
         {
@@ -30,7 +30,7 @@
             "hash": "982fb8ea6442d16de0f7c0b2f062595ba25fed0d4e0c03248b7c20e7164ffa82",
             "type": "shell"
         },
-	{
+        {
             "item": "Configure Screensaver",
             "version": "",
             "url": "repo/screensaver.sh",
@@ -51,33 +51,43 @@
             "type": "shell"
         },
         {
-            "item": "Configure Dock",
+            "item": "Download Crashplan custom.properties",
             "version": "",
-            "url": "repo/dock-config.sh",
+            "url": "repo/custom.properties",
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "3395fd4b292a298944980af30d97e52ff956d8c0021d4b26a6c294026f78d3bf",
-            "type": "shell"
+            "hash": "aca997947edd05c808034c019c7e43633cc482050b8f7d2e58d65f10e8cfaf56",
+            "type": "file"
         },
         {
-            "item": "Install Crashplan",
+            "item": "Download Crashplan userInfo.sh",
+            "version": "",
+            "url": "repo/userInfo.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "1d0373d3aa6431257ed552f87ce9c986a19f42fc9ed1d99ae7f4c8b0cf996852",
+            "type": "file"
+        },
+        {
+            "item": "Download Crashplan",
             "version": "4.5.2",
             "url": "https://download.code42.com/installs/mac/install/CrashPlanPROe/CrashPlanPROe_${version}_Mac.dmg",
             "filename": "",
-            "dmg-installer": "Install CrashPlan PROe.pkg",
+            "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "21fcf556dc06f06ff81956901414d71c1a168974567189aadd934ede8b1f6d91",
             "type": "dmg"
         },
         {
-            "item": "Crashplan PostInstall",
+            "item": "Crashplan Custom Install",
             "version": "",
             "url": "repo/crashplan-postinstall.sh",
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "3b8711139c03f203330c55db8d55a4311d46a0df6addc28111a9ab7d4578be72",
+            "hash": "66c81396666a6a4318cf78eaa7bf33ac77dfa53ef3ea32bd57dd9a5965e88526",
             "type": "shell"
         },
         {
@@ -138,6 +148,16 @@
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "5de09057abdbc563d0cc4f802ab3138d901dd1ba711f7ddcf6de99299a54affb",
+            "type": "shell"
+        },
+        {
+            "item": "Configure Dock",
+            "version": "",
+            "url": "repo/dock-config.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "3395fd4b292a298944980af30d97e52ff956d8c0021d4b26a6c294026f78d3bf",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,16 @@
             "type": "shell"
         },
         {
+            "item": "Download Wallpaper Image",
+            "version": "",
+            "url": "repo/wallpaper.jpg",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
+            "type": "file-lfs"
+        },
+	{
             "item": "Configure Screensaver",
             "version": "",
             "url": "repo/screensaver.sh",
@@ -49,16 +59,6 @@
             "dmg-advanced": "",
             "hash": "3b8711139c03f203330c55db8d55a4311d46a0df6addc28111a9ab7d4578be72",
             "type": "shell"
-        },
-        {
-            "item": "Download Wallpaper Image",
-            "version": "",
-            "url": "repo/wallpaper.jpg",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
-            "type": "file-lfs"
         },
         {
             "item": "Install Firefox",

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,16 @@
             "type": "shell"
         },
         {
+            "item": "Configure Wallpaper",
+            "version": "",
+            "url": "repo/wallpaper.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "982fb8ea6442d16de0f7c0b2f062595ba25fed0d4e0c03248b7c20e7164ffa82",
+            "type": "shell"
+       },
+       {
             "item": "Download Wallpaper Image",
             "version": "",
             "url": "repo/wallpaper.jpg",
@@ -38,6 +48,16 @@
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "26f27eff72ee2d335bd2948291a1b4173c63186fd2504dc08be9b94755abd325",
+            "type": "shell"
+        },
+        {
+            "item": "Configure Dock",
+            "version": "",
+            "url": "repo/dock-config.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "3395fd4b292a298944980af30d97e52ff956d8c0021d4b26a6c294026f78d3bf",
             "type": "shell"
         },
         {
@@ -98,26 +118,6 @@
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "a3476f968ac645dffcecc336a0b735a7f508b30f75c9a3222e211100e58d5c0e",
-            "type": "shell"
-        },
-        {
-            "item": "Configure Wallpaper",
-            "version": "",
-            "url": "repo/wallpaper.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "982fb8ea6442d16de0f7c0b2f062595ba25fed0d4e0c03248b7c20e7164ffa82",
-            "type": "shell"
-        },
-        {
-            "item": "Configure Dock",
-            "version": "",
-            "url": "repo/dock-config.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "3395fd4b292a298944980af30d97e52ff956d8c0021d4b26a6c294026f78d3bf",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "aca997947edd05c808034c019c7e43633cc482050b8f7d2e58d65f10e8cfaf56",
+            "hash": "4ff51f41dd634f509f107c60400a7a312b0a765a813f83420adb03f9cba96e5a",
             "type": "file"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -11,16 +11,6 @@
             "type": "shell"
         },
         {
-            "item": "Configure Wallpaper",
-            "version": "",
-            "url": "repo/wallpaper.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "982fb8ea6442d16de0f7c0b2f062595ba25fed0d4e0c03248b7c20e7164ffa82",
-            "type": "shell"
-       },
-       {
             "item": "Download Wallpaper Image",
             "version": "",
             "url": "repo/wallpaper.jpg",
@@ -29,6 +19,16 @@
             "dmg-advanced": "",
             "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
             "type": "file-lfs"
+        },
+        {
+            "item": "Configure Wallpaper",
+            "version": "",
+            "url": "repo/wallpaper.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "982fb8ea6442d16de0f7c0b2f062595ba25fed0d4e0c03248b7c20e7164ffa82",
+            "type": "shell"
         },
 	{
             "item": "Configure Screensaver",

--- a/repo/custom.properties
+++ b/repo/custom.properties
@@ -1,0 +1,76 @@
+###################################################################################################
+##
+## custom.properties
+## Edit these properties to customize and/or simplify the user's experience.
+## http://www.code42.com/r/support/custom.sh-3.6.1.4
+##
+###################################################################################################
+## Authority properties
+## Skip the register/login screens by providing address, registrationKey, username, and password.
+##
+## Authority Parameters
+## ${username}
+##     determined from the CP_USER_NAME command-line argument, the CP_USER_NAME environment variable, 
+##     or "user.name" Java system property from the user interface once it launches.
+## ${computername} - system computer name
+## ${generated}    - random 8 characters, typically used for password
+## ${uniqueId}     - a globally unique id, a large number
+## ${deferred}
+##     for LDAP and Auto register only! This allows them to register without password 
+##     and requires user to login to CPD the first time.
+
+## the primary address and port to the authority that manages the accounts and issues licenses
+## Example:  internalhost:4282
+address=clientbackup.mozilla.com:4282
+
+## the secondary address and port to the authority that manages the accounts and issues licenses. 
+## Note: This is an advanced setting. Use only if you are familiar with its use and results.
+## Example:  externalhost:4282
+secondaryAddress=
+
+## Do not prompt or allow user to change the address (true or false)
+hideAddress=false
+
+## Lock server address setting so that user cannot change server address (true or false)
+lockedAddress=false
+
+## The organization registration key, when specified the field is hidden in the register/login screen
+## Example: AAAA-BBBB-CCCC-DDDD
+registrationKey=
+
+## The username to use when authorizing the computer.
+## Accepts any authority parameters listed above.
+username="${username}@mozilla.com"
+
+## The password used when authorizing the computer.
+## Accepts any authority parameters listed above.
+password=
+
+
+##################################################################################################
+## Proxy properties
+## Enable the use of a proxy server when devices running the CrashPlan app must use a proxy server 
+## to connect to a Code 42 enterprise server instance that is external to the LAN. 
+## The proxy server must be accessible to all devices running the CrashPlan app.
+proxy.enable=false
+
+## The URL for the proxy server
+proxy.pacUrl=test
+
+
+##################################################################################################
+## Single Sign-on properties
+
+## SsoAuth will not be available unless this is true. Default is false.
+ssoAuth.enabled=true
+
+## Login via sso is enforced, the login with sso button is hidden. SSO must be enabled. Default is false.
+ssoAuth.required=false
+
+## Name of the SsoAuth identity provider. Only used if ssoAuth.enable=true. Default is "Shibboleth".
+ssoAuth.provider=single sign-on
+
+
+###################################################################################################
+## END
+###################################################################################################

--- a/repo/custom.properties
+++ b/repo/custom.properties
@@ -40,7 +40,7 @@ registrationKey=
 
 ## The username to use when authorizing the computer.
 ## Accepts any authority parameters listed above.
-username="${username}@mozilla.com"
+username=
 
 ## The password used when authorizing the computer.
 ## Accepts any authority parameters listed above.

--- a/repo/macos-versioncheck.sh
+++ b/repo/macos-versioncheck.sh
@@ -19,11 +19,17 @@ os_version=$(sw_vers -productVersion | awk -F '.' '{print $1}')
 major_version=$(sw_vers -productVersion | awk -F '.' '{print $2}')
 minor_version=$(sw_vers -productVersion | awk -F '.' '{print $3}')
 
-if ! [[ "$os_version" -ge "$expected_os" && "$major_version" -ge "$expected_major" && "$minor_version" -ge "$expected_minor" ]]; then
-    echo "UPGRADE REQUIRED: You are running macOS ${os_version}.${major_version}.${minor_version}"
-    echo "We are expecting: ${expected_os}.${expected_major}.${expected_minor}"
-    echo "The build will halt, please update macOS via the App Store and try again."
-    exit 1
+if [[ "$minor_version" -eq $null ]]; then
+    minor_version=0
+fi
+
+if ! [[ "$os_version" -ge "$expected_os" && "$major_version" -ge "$expected_major" ]]; then
+    if ! [[ "$major_version" -gt "$expected_major" ]]; then
+        echo "UPGRADE REQUIRED: You are running macOS ${os_version}.${major_version}.${minor_version}"
+        echo "We are expecting: ${expected_os}.${expected_major}.${expected_minor}"
+        echo "The build will halt, please update macOS via the App Store and try again."
+        exit 1
+    fi
 else
     echo "You are running macOS ${os_version}.${major_version}.${minor_version}, which meets the minimum requirements."
     exit 0

--- a/repo/userInfo.sh
+++ b/repo/userInfo.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+#
+# Optional script by which you can control the user installation.
+#
+# Variables to set:
+#   startDesktop: set to false if you don't want the desktop to start up immediately after installation 
+#      CP_USER_HOME: Allows the app to start scanning the user's home folder immediately after installation
+#      user:         Used to properly set file permissions
+#      userGroup:    Also used for file permissions
+#      CP_USER_NAME: This will become the unique ID for the user in the PROe Server database.
+#                    Leave CP_USER_NAME blank to require the user to enter it.
+#                    If set this value, you'll want to set the username="" attribute of <authority ... /> tag in default.service.xml to username="${username}"
+#
+
+#
+# Set to false if you don't want the desktop UI to start up.
+#
+startDesktop=false
+
+#
+# When installing from the root account (for example) you will need to populate
+# some or all of these variables differently than is done below. 
+# Note: whoami *always* returns "root" for this package so we had to get creative to find the installing user.
+# Also: You will want to populate CP_USER_NAME with the right email address unless you don't want your users or admins receiving reports and alerts. 
+# 
+CP_USER_HOME="$HOME"
+user=`basename $CP_USER_HOME`
+userGroup=`id -gn "$user"`
+CP_USER_NAME="$user"
+
+
+# 
+# Users have suggested alternate ways of finding the user name and email address.
+# The following examples may work better for your situation.
+# 
+#user=`last -1 | awk '{print $1}'`
+
+# This assumes the username is the last part of the home folder name
+#user=`basename "$CP_USER_HOME"`
+
+# This parses the user from the computer hostname
+# Because the APL naming convention uses the name of the owner in the computer name we will use this
+# to derive the primary user name. So the primary user does not have to be logged in for this to work.
+#computerName=`scutil --get ComputerName`
+#user=${computerName%%-*}
+
+# This finds the email address from AD or LDAP
+#dsclEmail=`dscl /Search read /Users/$user mail`
+#CP_USER_NAME=${dsclEmail##*mail: }
+
+# Run As User
+# Uncomment the following line if you want the service to run as user instead of root.
+#touch "${TMPDIR}/.cpRunAsUser"


### PR DESCRIPTION
Making Mojave work with Dinobuildr was a little tricker than anticipated, but mostly because we had taken some shortcuts and had a few bugs in some scripts. Here's the important stuff

### Wallpaper
It's now harder to set the wallpaper in Mojave without using Configuration Profiles, because any calls to `osascript` need to be authorized by the user, regardless of if `osascript` was called with `sudo` or not. This is actually a good change, as it means that less sketchy stuff can be done with `osascript`, but it means that there is a prompt that you have to click through in our build. I moved this step to right after the OS version check to make it easy to get out of the way quickly. 

![image](https://user-images.githubusercontent.com/5789441/46045794-924dba00-c0d3-11e8-9be9-07d3d76b9301.png)

### Recently Used Apps in the Dock
Apple added a feature where apps that you launch magically appear in the dock in a separate section, and stick around (because, since you launched them, they might be helpful). This is neat, but there is no programmatic way of clearing these dock items, so Terminal will now show up in the user's dock because we use Terminal to set up their machine. I think this is fine, but we can add manual steps to remediate this in the future. 

### Crashplan changes
We were installing Crashplan in kind of a sketchy way. By default, Crashplan auto-launches, which is annoying. Code42 has a way of pre-configuring the installer to avoid this behavior, but it involves injecting post-installation scripts into the installer DMG, which was a pain, so we were just auto-quitting the app after install with a post-installation script. This was lame, and we should've just done this the right way in the first place - so I wrote a proper post-installation script and included all the assets in the build. 

### Generic File Downloader
We can no download generic text files, including scripts, out of our Github repo. This is used to grab the Crashplan pre-installation assets, while keeping them in user-readable plain-text. 

### DMG Handler Cleanup
I needed to clean up the DMG handler a bit so it's a little more verbose about what it's actually doing. I also added a new "feature" which is a bit of a work around: if you don't specify an installer path or an `advanced_dmg` command, the handler will just download the DMG. This is useful for pre-installation injection, like we do with Crashplan, but this should be handled by a generic file downloader in the future. 