### PR TITLE
Disable Guest Account and set the wallpaper via a different method

### DIFF
--- a/ambient_manifest.json
+++ b/ambient_manifest.json
@@ -171,6 +171,16 @@
             "type": "mobileconfig"
         },
         {
+            "item": "Disable Guest Login",
+            "version": "",
+            "url": "repo/disable-guest.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "b4d565ca544ffa7559ccfab4d80467316f9c6531f1f7d0b97cc9010553876216",
+            "type": "shell"
+        },
+        {
             "item": "Update macOS",
             "version": "",
             "url": "repo/update-macos.sh",

--- a/config.py
+++ b/config.py
@@ -81,13 +81,8 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-<<<<<<< HEAD
-default_manifest_hash = "3fce17a83f63c869025e2072e3ed6f46677390fccb073ae3081e36aaf3d03f47"
-ambient_manifest_hash = "153b5cd48a45aed3811295858e2937be687d751085304bb5b40df5182f0ff4e5"
-=======
 default_manifest_hash = "533caf6e097dd2189d38fdf99f343ec5261dd594442e954f5e30384c23e17aab"
 ambient_manifest_hash = "56592f48558895ed8ab693095d00bca58f676d42316c5d22420c8df9b95d3442"
->>>>>>> feat-nopromptbg
 manifest_hash = default_manifest_hash
 
 if manifest == "ambient_manifest.json":

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "8229cd5f91fbfd270a0e00fbd45de31ee7f2a097ca6a2fd8be495efd277d9d76"
+default_manifest_hash = "aa4bfe165331150fcde2bac301355aad74543a5c1e62707a7c86825010b85edc"
 ambient_manifest_hash = "ab4b17776386a3d543947f4ed106e5030943ca0355f96a4edc8d2f26bd70c9fb"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "0d1548d2034bc2fef88eb47a6ac65e786a220b4cd7d560777cc2a87557eab21b"
+default_manifest_hash = "3fce17a83f63c869025e2072e3ed6f46677390fccb073ae3081e36aaf3d03f47"
 ambient_manifest_hash = "153b5cd48a45aed3811295858e2937be687d751085304bb5b40df5182f0ff4e5"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "ca83d31bafdf8186a00ef7a0e11b23cf0bb006142e4d827f197f3c30bf0bad6a"
+default_manifest_hash = "8229cd5f91fbfd270a0e00fbd45de31ee7f2a097ca6a2fd8be495efd277d9d76"
 ambient_manifest_hash = "ab4b17776386a3d543947f4ed106e5030943ca0355f96a4edc8d2f26bd70c9fb"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -81,7 +81,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "95769cfbb0d0672bcb8e225445aefd53b246d8cfc6dccda9438a07df2dee9c71"
+default_manifest_hash = "ca83d31bafdf8186a00ef7a0e11b23cf0bb006142e4d827f197f3c30bf0bad6a"
 ambient_manifest_hash = "ab4b17776386a3d543947f4ed106e5030943ca0355f96a4edc8d2f26bd70c9fb"
 manifest_hash = default_manifest_hash
 

--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "533caf6e097dd2189d38fdf99f343ec5261dd594442e954f5e30384c23e17aab"
-ambient_manifest_hash = "56592f48558895ed8ab693095d00bca58f676d42316c5d22420c8df9b95d3442"
+ambient_manifest_hash = "153b5cd48a45aed3811295858e2937be687d751085304bb5b40df5182f0ff4e5"
 manifest_hash = default_manifest_hash
 
 if manifest == "ambient_manifest.json":

--- a/config.py
+++ b/config.py
@@ -81,8 +81,8 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "533caf6e097dd2189d38fdf99f343ec5261dd594442e954f5e30384c23e17aab"
-ambient_manifest_hash = "153b5cd48a45aed3811295858e2937be687d751085304bb5b40df5182f0ff4e5"
+default_manifest_hash = "95769cfbb0d0672bcb8e225445aefd53b246d8cfc6dccda9438a07df2dee9c71"
+ambient_manifest_hash = "ab4b17776386a3d543947f4ed106e5030943ca0355f96a4edc8d2f26bd70c9fb"
 manifest_hash = default_manifest_hash
 
 if manifest == "ambient_manifest.json":

--- a/manifest.json
+++ b/manifest.json
@@ -157,7 +157,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "3395fd4b292a298944980af30d97e52ff956d8c0021d4b26a6c294026f78d3bf",
+            "hash": "1096e180fcde42c72b777c0db5b53083191ce934864cf89cdd4f0d90153fc540",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -161,6 +161,15 @@
             "type": "shell"
         },
         {
+            "item": "Disable Guest Login",
+            "version": "",
+            "url": "repo/disable-guest.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "b4d565ca544ffa7559ccfab4d80467316f9c6531f1f7d0b97cc9010553876216",
+            "type": "shell"
+        },{
             "item": "Update macOS",
             "version": "",
             "url": "repo/update-macos.sh",

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "cfb0b337efde6c9cbb8ed6d33efe1aeabac291a245526a12a7a073ad7be77743",
+            "hash": "00eecf9fca8eb9af939b8c110f2aafa0dc68d7b17e6f110a5453efddd6eb85b6",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "00eecf9fca8eb9af939b8c110f2aafa0dc68d7b17e6f110a5453efddd6eb85b6",
+            "hash": "4ec72aedc61c6b5554e3bc6b04a90431da68a78740611d591d62f22aa8bc9cbe",
             "type": "shell"
         },
         {

--- a/manifest.json
+++ b/manifest.json
@@ -169,7 +169,8 @@
             "dmg-advanced": "",
             "hash": "b4d565ca544ffa7559ccfab4d80467316f9c6531f1f7d0b97cc9010553876216",
             "type": "shell"
-        },{
+        },
+        {
             "item": "Update macOS",
             "version": "",
             "url": "repo/update-macos.sh",

--- a/repo/disable-guest.sh
+++ b/repo/disable-guest.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Disable the guest account via plist
+
+defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool FALSE
+
+exit 0

--- a/repo/dock-config.sh
+++ b/repo/dock-config.sh
@@ -14,7 +14,7 @@
 # the hash or the url without testing.
 
 hash="c49ba68db90f7ac3a50a490e597078df6de6a8feba16c24ccced7b34d84f705e" # change only after thorough testing
-dockutil=$(curl -fsSL https://raw.githubusercontent.com/kcrawford/dockutil/b7fcec8aae863cd83cb27c2cf8bd3e739ece0795/scripts/dockutil)
+dockutil=$(curl -fsSL https://raw.githubusercontent.com/mozilla/dockutil/26b13d380f67dc79251cf0ea6280dbaa603308be/scripts/dockutil)
 
 if [ $(echo "$dockutil" | shasum -a 256 | awk {'print $1'}) == $hash ]; then #  if the hashes match then proceed
     echo "Executing dockutil - hash matches expected value."

--- a/repo/wallpaper.sh
+++ b/repo/wallpaper.sh
@@ -11,7 +11,10 @@
 # on.
 #
 # You can see Steve's script the follow github repo: https://github.com/tech-otaku/macos-desktop
-
+# 
+# We fork the repo so that we can ensure that we have access to a version of
+# this project. 
+# 
 # Set the filename of the wallpaper file
 
 WALLPAPER_FILENAME=wallpaper.jpg
@@ -43,8 +46,8 @@ if [[ "$os_version" -le "10" && "$major_version" -le "13" ]]; then
     $(which osascript) -e 'tell application "Finder" to set desktop picture to POSIX file "/Users/Shared/'"$WALLPAPER_FILENAME"'"'
 else
 
-    WALLPAPER_SH=$(curl -sc - https://raw.githubusercontent.com/tech-otaku/macos-desktop/3e29f30853552e2288c56699b3214ecff6fed44b/set-desktop-mojave.sh)
-    HASH="e42761c63203225ba46e9e460ea07b23738bc5e3a5b19d425a6314688a445d4b" # change only after thorough testing
+    WALLPAPER_SH=$(curl -sc - https://raw.githubusercontent.com/mozilla/macos-desktop/abfb607953e0c789bb8e853ec28f545e89ddebbe/set-desktop-mojave.sh)
+    HASH="50b049f9cf9a57582fa83f411b66c61fed854f553102c05ca91cbd249cdb9ac8" # change only after thorough testing
 
     if [ $(echo "$WALLPAPER_SH" | shasum -a 256 | awk {'print $1'}) == $HASH ]; then #  if the hashes match then proceed
         echo "We're on Mojave (or newer) so we're going to use the new way to set the wallpaper."

--- a/repo/wallpaper.sh
+++ b/repo/wallpaper.sh
@@ -45,7 +45,6 @@ if [[ "$os_version" -le "10" && "$major_version" -le "13" ]]; then
     echo "Since this is a pre-Mojave machine, we are setting the wallpaper the old-fashioned way."
     $(which osascript) -e 'tell application "Finder" to set desktop picture to POSIX file "/Users/Shared/'"$WALLPAPER_FILENAME"'"'
 else
-
     WALLPAPER_SH=$(curl -sc - https://raw.githubusercontent.com/mozilla/macos-desktop/abfb607953e0c789bb8e853ec28f545e89ddebbe/set-desktop-mojave.sh)
     HASH="50b049f9cf9a57582fa83f411b66c61fed854f553102c05ca91cbd249cdb9ac8" # change only after thorough testing
 


### PR DESCRIPTION
This is a two-features for the price of one type of deal. 

After Mojave, setting the desktop wallpaper became more complicated, as using the old tried and true [applescript method](https://github.com/mozilla/dinobuildr/blob/1ab397d9bc27ea538ab56a5a9c817a372d4f0aae/repo/wallpaper.sh) resulted in a TCC prompt. 

We solve for this by using [Steve Ward's method](https://github.com/tech-otaku/macos-desktop) for setting the desktop wallpaper the "proper way" in Mojave using a shell script. We curl down a commit-pinned version of this script and execute it. 

We also are disabling the Guest Login feature of macOS. With Filevault enabled, the Guest account only has access to Safari and the disk is still encrypted, but since this isn't a feature most people will likely use we're turning it off. 