### PR TITLE
Update firefox-bookmarks.sh, add Zoom, remove Vidyo

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "29a75b8d91ea40e5660f1449f71522e7af1ff6f32488c846942f0af83b09f390"
+default_manifest_hash = "01ec13b53c785a996c58ff9430ddaa466965beb8ae049718d7d2ec354696725e"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -144,8 +144,9 @@ def pkg_install(package):
     stdout, stderr = pipes.communicate()
     if pipes.returncode == 1:
         print stdout
-        print stderr 
+        print stderr
         exit(1)
+
 
 # the script executer executes any .sh file using bash and pipes stdout and
 # stderr to the python console. the return code of the script execution can be
@@ -172,7 +173,7 @@ def dmg_install(filename, installer, command=None):
     stdout, stderr = pipes.communicate()
     if pipes.returncode == 1:
         print stdout
-        print stderr 
+        print stderr
         exit(1)
     volume_path = re.search(r'(\/Volumes\/).*$', stdout).group(0)
     installer_path = "%s/%s" % (volume_path, installer)
@@ -185,7 +186,7 @@ def dmg_install(filename, installer, command=None):
         stdout, stderr = pipes.communicate()
         if pipes.returncode == 1:
             print stdout
-            print stderr 
+            print stderr
             exit(1)
     if ".pkg" in installer:
         installer_destination = "%s/%s" % (local_dir, installer)
@@ -204,8 +205,9 @@ def dmg_install(filename, installer, command=None):
     stdout, stderr = pipes.communicate()
     if pipes.returncode == 1:
         print stdout
-        print stderr 
+        print stderr
         exit(1)
+
 
 # the mobileconfig_install function installs configuration profiles
 def mobileconfig_install(mobileconfig):
@@ -215,8 +217,9 @@ def mobileconfig_install(mobileconfig):
     stdout, stderr = pipes.communicate()
     if pipes.returncode == 1:
         print stdout
-        print stderr 
+        print stderr
         exit(1)
+
 
 # the hash_file function accepts two arguments: the filename that you need to
 # determine the SHA256 hash of and the expected hash it returns True or False.

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "0092309b41a548c79196211f8b5670dfe65861fcfa3e16b3e6ee06430a02b422"
+default_manifest_hash = "890886f6a946997c8ce789008f812058eceead293264abb4e4c1bd38e239406d"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "f4c9b632ae1eda75a78ced7e2fa30a548d288a64cbc0af602d15178b04f69286"
+default_manifest_hash = "0092309b41a548c79196211f8b5670dfe65861fcfa3e16b3e6ee06430a02b422"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -310,7 +310,7 @@ for item in data['packages']:
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
         hash_file(local_path, item['hash'])
-        print "Installing:", item['local_path']
+        print "Installing:", item['item']
         pkg_install(local_path)
         print "\r"
 
@@ -319,7 +319,7 @@ for item in data['packages']:
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
         hash_file(local_path, item['hash'])
-        print "Installing:", item['local_path']
+        print "Installing:", item['item']
         pkg_install(local_path)
         print "\r"
 
@@ -368,8 +368,8 @@ for item in data['packages']:
         lfsfile_url = get_lfs_url(json_data, lfs_url)
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
-        print "File downloaded to", item['local_path']
         hash_file(local_path, item['hash'])
+        print "File downloaded to:", local_path
         print "\r"
 
     if item['type'] == "file":
@@ -379,8 +379,8 @@ for item in data['packages']:
         dl_url = raw_url + item['url']
         print "Downloading:", item['item']
         downloader(dl_url, local_path)
-        print "File downloaded to", item['local_path']
         hash_file(local_path, item['hash'])
+        print "File downloaded to:", local_path
         print "\r"
 
     if item['type'] == "mobileconfig":

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -325,7 +325,7 @@ for item in data['packages']:
         print "\r"
 
     if item['type'] == "pkg":
-        dl_url = item['url']
+        dl_url = item['url'].replace('${version}', item['version'])
         print "Downloading:", item['item']
         downloader(dl_url, local_path)
         hash_file(local_path, item['hash'])

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "4cf576ef390f5fee38217d434a67f81600bb6d7e333477f078556f6082e3f413"
+default_manifest_hash = "29a75b8d91ea40e5660f1449f71522e7af1ff6f32488c846942f0af83b09f390"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "9fb7796c003d2b858a115c22793ab84d41b0464eaab96fbf1cd3a8f166acd04d"
+default_manifest_hash = "9449fcc5e537bd5df87ddffb535713e2d0850daf700cc5ade8ffc9003ccf6651"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "8e9bae9d417d0f2ac844c80f54520ea15606afd914e78f9b92895b9eec61f7ca"
+default_manifest_hash = "f4c9b632ae1eda75a78ced7e2fa30a548d288a64cbc0af602d15178b04f69286"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "5440c788dada82a46b199346b7d5e6d56b68e168709063b73664ab2882599fb7"
+default_manifest_hash = "29a75b8d91ea40e5660f1449f71522e7af1ff6f32488c846942f0af83b09f390"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -313,6 +313,14 @@ for item in data['packages']:
         pkg_install(local_path)
         print "\r"
 
+    if item['type'] == "pkg":
+        dl_url = raw_url + item['url']
+        print "Downloading:", item['item']
+        downloader(lfsfile_url, local_path)
+        hash_file(local_path, item['hash'])
+        pkg_install(local_path)
+        print "\r"
+
     if item['type'] == "shell":
         dl_url = raw_url + item['url']
         print "Downloading:", item['item']

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "9449fcc5e537bd5df87ddffb535713e2d0850daf700cc5ade8ffc9003ccf6651"
+default_manifest_hash = "59b1b61ef0b1cfa1be283e41715e45d24aee44f982212d2ca57ff01c81025c1f"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "890886f6a946997c8ce789008f812058eceead293264abb4e4c1bd38e239406d"
+default_manifest_hash = "5440c788dada82a46b199346b7d5e6d56b68e168709063b73664ab2882599fb7"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -310,6 +310,7 @@ for item in data['packages']:
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
         hash_file(local_path, item['hash'])
+        print "Installing:", item['local_path']
         pkg_install(local_path)
         print "\r"
 
@@ -318,6 +319,7 @@ for item in data['packages']:
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
         hash_file(local_path, item['hash'])
+        print "Installing:", item['local_path']
         pkg_install(local_path)
         print "\r"
 
@@ -366,6 +368,7 @@ for item in data['packages']:
         lfsfile_url = get_lfs_url(json_data, lfs_url)
         print "Downloading:", item['item']
         downloader(lfsfile_url, local_path)
+        print "File downloaded to", item['local_path']
         hash_file(local_path, item['hash'])
         print "\r"
 
@@ -376,6 +379,7 @@ for item in data['packages']:
         dl_url = raw_url + item['url']
         print "Downloading:", item['item']
         downloader(dl_url, local_path)
+        print "File downloaded to", item['local_path']
         hash_file(local_path, item['hash'])
         print "\r"
 
@@ -384,7 +388,7 @@ for item in data['packages']:
         print "Downloading:", item['item']
         downloader(dl_url, local_path)
         hash_file(local_path, item['hash'])
-        print "Installing:", item['item']
+        print "Applying Mobileconfig:", item['item']
         mobileconfig_install(local_path)
         print "\r"
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "29a75b8d91ea40e5660f1449f71522e7af1ff6f32488c846942f0af83b09f390"
+default_manifest_hash = "ef34e8eb741ad7146c476f9a1f62c02256422bb0771fc80e04a83266e4bb7ee8"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -83,7 +83,7 @@ lfs_url = "https://github.com/%s/%s.git/info/lfs/objects/batch" % (org, repo)
 raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
-default_manifest_hash = "59b1b61ef0b1cfa1be283e41715e45d24aee44f982212d2ca57ff01c81025c1f"
+default_manifest_hash = "8e9bae9d417d0f2ac844c80f54520ea15606afd914e78f9b92895b9eec61f7ca"
 ambient_display_manifest_hash = "d291d6dd00a69490798970a40dff9e13340455db6b3711c843e90a5f48733772"
 manifest_hash = default_manifest_hash
 

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,8 +103,8 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/${version}/Zoom.pkg",
-            "filename": "zoom.pkg",
+            "url": "https://zoom.us/client/4.4.52595.0425/Zoom.pkg",
+            "filename": "Zoom.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be",
@@ -138,16 +138,6 @@
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "5de09057abdbc563d0cc4f802ab3138d901dd1ba711f7ddcf6de99299a54affb",
-            "type": "shell"
-        },
-        {
-            "item": "Configure Dock",
-            "version": "",
-            "url": "resources/dock-config.sh",
-            "filename": "",
-            "dmg-installer": "",
-            "dmg-advanced": "",
-            "hash": "11fc69ed7fe89de385bd0968709f9481eebf52172b27b283d5cb53fa8709a0b6",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -47,7 +47,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "67db5d7c7c5c4a2dc99ee619388dfb8da5c0af1bfed4b7f2d0173e257634e724",
+            "hash": "f933954b5e4e82fa3aed0c7d81d6f5659b49eac1129fe331d09ec7afae0e3ceb",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -108,7 +108,7 @@
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be",
-            "type": "pkg-lfs"
+            "type": "pkg"
         },
         {
             "item": "Configure Firewall",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -107,7 +107,7 @@
             "filename": "Zoom.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be",
+            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
             "type": "pkg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -82,12 +82,12 @@
         },
         {
             "item": "Install Firefox",
-            "version": "65.0.2",
+            "version": "66.0.5",
             "url": "https://download.mozilla.org/?product=firefox-${version}-SSL&os=osx&lang=en-US",
             "filename": "firefox.dmg",
             "dmg-installer": "Firefox.app",
             "dmg-advanced": "",
-            "hash": "8eeb1fdc8bea3465dc4a9914957185fdf15fd092ddf57694b7f3476d72d42826",
+            "hash": "cabe2fe0832df2ef1c81a953c28844d78c38d5046ca7cfbaf6601d1c1a465235",
             "type": "dmg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,11 +103,11 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/${version}/ZoomInstallerIT.pkg",
+            "url": "https://zoom.us/client/4.4.52595.0425/ZoomInstallerIT.pkg",
             "filename": "ZoomInstallerIT.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
+            "hash": "9c8c585d3becb576716e9bc06d7f0c080948d2369013b977aefa5e0cbb3eaedb",
             "type": "pkg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -107,7 +107,7 @@
             "filename": "ZoomInstallerIT.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "9c8c585d3becb576716e9bc06d7f0c080948d2369013b977aefa5e0cbb3eaedb",
+            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
             "type": "pkg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -101,14 +101,14 @@
             "type": "shell"
         },
         {
-            "item": "Install Vidyo",
-            "version": "3.6.14",
-            "url": "https://v.mozilla.com/upload/VidyoDesktopInstaller-macosx-TAG_VD_3_6_14_0003.dmg",
-            "filename": "vidyodesktop.dmg",
-            "dmg-installer": "VidyoDesktopInstaller.app/Contents/Resources/VidyoDesktop.app",
+            "item": "Install Zoom",
+            "version": "4.4.52595.0425",
+            "url": "https://zoom.us/client/${version}/Zoom.pkg",
+            "filename": "zoom.pkg",
+            "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "d99548771c014636876cb5cca8bcbf9ca6f0800855cde8ba25aeffce636cceb1",
-            "type": "dmg"
+            "hash": "85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be",
+            "type": "pkg"
         },
         {
             "item": "Configure Firewall",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,11 +103,11 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/${version}/Zoom.pkg",
+            "url": "https://zoom.us/client/${version}/ZoomInstallIT.pkg",
             "filename": "Zoom.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "8b5771b813bd684ee3ff8f6a2c205c249ca127c7c5f92c9b92b1b8fdecd389a4",
+            "hash": "9c8c585d3becb576716e9bc06d7f0c080948d2369013b977aefa5e0cbb3eaedb",
             "type": "pkg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -147,7 +147,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "11fc69ed7fe89de385bd0968709f9481eebf52172b27b283d5cb53fa8709a0b6",
+            "hash": "5063270b1401b98ac417ebd5eb4199c77b9894750b08ee3b6573823f310472ff",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -97,7 +97,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "5d6cb5e71deb217f278b5fb5c5240482ddd701fd81bdb221c0884745024c6f65",
+            "hash": "de78e5e82c2c811b2951428a3fdd5ccf6ec20063dff34210105c99b8de719f52",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,7 +103,7 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/4.4.52595.0425/ZoomInstallerIT.pkg",
+            "url": "https://zoom.us/client/${version}/ZoomInstallerIT.pkg",
             "filename": "ZoomInstallerIT.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,8 +103,8 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/${version}/ZoomInstallIT.pkg",
-            "filename": "Zoom.pkg",
+            "url": "https://zoom.us/client/${version}/ZoomInstallerIT.pkg",
+            "filename": "ZoomInstallerIT.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "9c8c585d3becb576716e9bc06d7f0c080948d2369013b977aefa5e0cbb3eaedb",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -103,12 +103,12 @@
         {
             "item": "Install Zoom",
             "version": "4.4.52595.0425",
-            "url": "https://zoom.us/client/4.4.52595.0425/Zoom.pkg",
+            "url": "https://zoom.us/client/${version}/Zoom.pkg",
             "filename": "Zoom.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
             "hash": "85c96d9ee17e700f6cd1a1ca205823ff6cdec8ada0812f2826e02cbd763035be",
-            "type": "pkg"
+            "type": "pkg-lfs"
         },
         {
             "item": "Configure Firewall",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -141,6 +141,16 @@
             "type": "shell"
         },
         {
+            "item": "Configure Dock",
+            "version": "",
+            "url": "resources/dock-config.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "11fc69ed7fe89de385bd0968709f9481eebf52172b27b283d5cb53fa8709a0b6",
+            "type": "shell"
+        },
+        {
             "item": "Disable Guest Login",
             "version": "",
             "url": "resources/disable-guest.sh",

--- a/resources/dock-config.sh
+++ b/resources/dock-config.sh
@@ -23,8 +23,8 @@ if [ "$(echo "$dockutil" | shasum -a 256 | awk '{print $1}')" == $hash ]; then #
     python -c "$dockutil" --remove all --no-restart
     python -c "$dockutil" --add "/Applications/Launchpad.app" --position beginning --no-restart
     python -c "$dockutil" --add "/Applications/Firefox.app" --after Launchpad --no-restart
-    python -c "$dockutil" --add "/Applications/VidyoDesktop.app" --after Firefox --no-restart
-    python -c "$dockutil" --add "/Applications/CrashPlan.app" --after VidyoDesktop --no-restart
+    python -c "$dockutil" --add "/Applications/zoom.us.app" --after Firefox --no-restart
+    python -c "$dockutil" --add "/Applications/CrashPlan.app" --after zoom.us --no-restart
     python -c "$dockutil" --add "~/Downloads" --view fan --display stack --section others --no-restart
     python -c "$dockutil" --add "/Applications/System Preferences.app" --position end
 else 

--- a/resources/firefox-bookmarks.sh
+++ b/resources/firefox-bookmarks.sh
@@ -28,8 +28,8 @@ cat > /Applications/Firefox.app/Contents/Resources/distribution/policies.json <<
         "Placement": "toolbar"
       },
       {
-        "Title": "Vidyo Conferencing",
-        "URL": "https://v.mozilla.com",
+        "Title": "Mozilla SSO",
+        "URL": "https://sso.mozilla.com",
         "Placement": "toolbar"
       },
       {

--- a/resources/set-computername.sh
+++ b/resources/set-computername.sh
@@ -27,3 +27,4 @@ echo "Setting LocalHostName and ComputerName to ${hostname}"
 
 scutil --set LocalHostName "$hostname"
 scutil --set ComputerName "$hostname"
+scutil --set HostName "$hostname"


### PR DESCRIPTION
Switching out the old Vidyo bookmark to sso.mozilla.com

## Deep Dive
This started as a basic update but ended up spiraling into bigger changes. 

### Added PKG support
Apparently this never got done and we hadn't previously needed it. We supported `pkgs` in LFS, but not `pkgs` pulled down from the internet. 

### Fixed stderr / stdout for PKG, DMG and Mobileconfig
This apparently had been broken all along. The fix is a little hacky, but time pressure. We'll now exit on installation errors. 

### Set the hostname properly
https://github.com/mozilla/dinobuildr/blob/1f48dfe2403f72564d471ca149ec5a2fae5b5fe5/resources/set-computername.sh#L30

You need all three!

### Updated our standard bookmark suite more significantly
Spring cleaning! Pass one, waiting on more input from the service desk team

### Swapped Vidyo for Zoom
removed old Vidyo app, added Zoom instead, updated Dock

### Updated Firefox