### PR TITLE
Revert "Allow video autoplay on Corsica screens"

### DIFF
--- a/resources/corsica/firefox-settings.sh
+++ b/resources/corsica/firefox-settings.sh
@@ -29,14 +29,10 @@ set +e
 
 mkdir /Users/Shared/corsica-profile
 
-# Set preferences
-# * full-screen-api.allow-trusted-requests-only = false - Allow Corsica to go full screen without interaction
-# * media.autoplay.default = 0 - Allow video autoplay, even with sound
 (
 set -e
 cat > /Users/Shared/corsica-profile/prefs.js <<- "EOF"
 user_pref("full-screen-api.allow-trusted-requests-only", false);
-user_pref("media.autoplay.default", 0);
 EOF
 set +e
 )


### PR DESCRIPTION
Reverts mozilla/dinobuildr#162

I haven't had a chance to test this yet but this won't likely run without updating the file hashes in the manifests (and the manifest hashes in the dino_engine.py). Suggest making those changes and retesting. 