### PR TITLE
External Repo Support

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -66,12 +66,12 @@ else:
     manifest = args.manifest
 
 if args.repo is None:
-    repo = default_repo 
+    repo = default_repo
 else:
     repo = args.repo
 
 if args.org is None:
-    org = default_org 
+    org = default_org
 else:
     org = args.org
 

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -34,8 +34,8 @@ global gid
 # default_branch - the default branch to build against if no --branch argument is specified
 # testing
 local_dir = "/var/tmp/dinobuildr"
-org = "mozilla"
-repo = "dinobuildr"
+default_org = "mozilla"
+default_repo = "dinobuildr"
 default_branch = "master"
 default_manifest = "production_manifest.json"
 
@@ -48,6 +48,10 @@ parser.add_argument("-b", "--branch",
                     help="The branch name to build against. Defaults to %s" % default_branch)
 parser.add_argument("-m", "--manifest",
                     help="The manifest to build against. Defaults to production macOS deployment.")
+parser.add_argument("-r", "--repo",
+                    help="The repo to build against. Defaults to %s" % default_repo)
+parser.add_argument("-o", "--org",
+                    help="The org to build against. Defaults to %s" % default_org)
 
 args = parser.parse_args()
 
@@ -60,6 +64,16 @@ if args.manifest is None:
     manifest = default_manifest
 else:
     manifest = args.manifest
+
+if args.repo is None:
+    repo = default_repo 
+else:
+    repo = args.repo
+
+if args.org is None:
+    org = default_org 
+else:
+    org = args.org
 
 # os.environ - an environment variable for the builder's local directory to be
 # passed on to shells scripts

--- a/dinobuildr.sh
+++ b/dinobuildr.sh
@@ -18,6 +18,7 @@ branch=master
 manifest=production_manifest.json
 repo=dinobuildr
 org=mozilla
+dino_engine=dino_engine.py
 
 while :; do
     case $1 in
@@ -73,7 +74,7 @@ fi
 printf "\nPulling down dinobuildr from the [%s] branch from the [%s] repo in the [%s] org on github.
 \n\n" "$branch" "$repo" "$org"
 
-build_script=$(curl -f https://raw.githubusercontent.com/mozilla/dinobuildr/"$branch"/dino_engine.py)
+build_script=$(curl -f https://raw.githubusercontent.com/"$org"/"$repo"/"$branch"/"$dino_engine")
 curl_status=$?
 
 # If curl fails for some reason, we return it's non-zero exit code so that the

--- a/dinobuildr.sh
+++ b/dinobuildr.sh
@@ -80,7 +80,7 @@ curl_status=$?
 # script can fail in a predictable way.
 
 if [ $curl_status -eq 0 ]; then
-    echo "Starting the build!\n"
+    printf "\nStarting the build!\n"
     if python -c "$build_script" -b "$branch" -m "$manifest" -r "$repo" -o "$org"; then
         echo "Rebooting!"
         osascript -e 'tell app "System Events" to restart' 


### PR DESCRIPTION
Adding support for external Github repos so folks from the community can PR changes and we can _actually test them_. 

This change adds the following optional flags to the `dinobuildr.sh`and `dino_engine.py` scripts: 
```
-r, --repo
    The name of the target Github repository (defaults to dinobuildr)
-o, --org
    The name of the target Github org (defaults to Mozilla)
```

Example usage: 
`sudo dinobuildr.sh -o luciusbono -r dinofork -b my-cool-test-branch`

This runs dinobuildr against branch called `my-cool-test-branch` in the `dinofork` repository in the `luciusbono` Github org. 