### PR TITLE
Removed lines in dmg_install function

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -189,8 +189,6 @@ def dmg_install(filename, installer, command=None):
             print stderr
             exit(1)
     if ".pkg" in installer:
-        installer_destination = "%s/%s" % (local_dir, installer)
-        shutil.copyfile(installer_path, installer_destination)
         pkg_install(installer_path)
     if ".app" in installer:
         applications_path = "/Applications/%s" % installer.rsplit('/', 1)[-1]


### PR DESCRIPTION
It’s unnecessary to copy the pkg file to the local_dir since we are executing the pkg file directly from the mounted dmg file.