### PR TITLE
Allowing autoplay media to play by default, as this is a change in FF68

### DIFF
--- a/ambient_display_manifest.json
+++ b/ambient_display_manifest.json
@@ -87,7 +87,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "df7ba7f2f12e1525b88753587f7c06149d2f79cec9bb9f98d3be0785f781a1e0",
+            "hash": "ae63aa2a891bdd327d0f8d6641e4004ec4b132c2bd19d7653443b1c661e7434d",
             "type": "shell"
         },
         {

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -98,7 +98,7 @@ raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
 manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
 manifest_file = "%s/%s" % (local_dir, manifest)
 default_manifest_hash = "5d0c82205869e7219ec76276408b5e562ea42af9637bbe74466f43667cae692b"
-ambient_display_manifest_hash = "4346a66e3178715aae583fbc392ea27df4f69c49e3247588d58ff92fabf4a5ff"
+ambient_display_manifest_hash = "7fd9fe4615df117c1679b0d50d53c45f9f7e116e556a8315ee84857992e2abdd"
 manifest_hash = default_manifest_hash
 
 if manifest == "ambient_display_manifest.json":

--- a/resources/corsica/firefox-settings.sh
+++ b/resources/corsica/firefox-settings.sh
@@ -36,6 +36,7 @@ mkdir /Users/Shared/corsica-profile
 set -e
 cat > /Users/Shared/corsica-profile/prefs.js <<- "EOF"
 user_pref("full-screen-api.allow-trusted-requests-only", false);
+user_pref("media.autoplay.default", 0);
 EOF
 set +e
 )


### PR DESCRIPTION
This was originally proposed (and implemented) by @mythmon in https://github.com/mozilla/dinobuildr/commit/57032b3d004be5f05877c834a09e3aac9664c852 but we had to back out the change (for other reasons) and my weak git-fu screwed everything up. 

This disables the auto-play blocking functionality in our ambient display boards, since we want things to automatically play. 