### PR TITLE
Fixing .app installer bug in DMG processor and removing hash checks for the manifest file

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -204,8 +204,7 @@ def main():
     parser.add_argument("-b", "--branch",
                         help="The branch name to build against. Defaults to %s" % default_branch)
     parser.add_argument("-m", "--manifest",
-                        help="The manifest to build against. "
-                             "Defaults to production macOS deployment.")
+                        help="The manifest to build against. Defaults to %s" % default_manifest)
     parser.add_argument("-r", "--repo",
                         help="The repo to build against. Defaults to %s" % default_repo)
     parser.add_argument("-o", "--org",
@@ -246,13 +245,6 @@ def main():
     raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
     manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
     manifest_file = "%s/%s" % (local_dir, manifest)
-    default_manifest_hash = "63d811f82c9ba54de15a7be0a7eca3c297eca9fe282595eedb301e358b24208c"
-    ambient_display_manifest_hash = \
-        "7fd9fe4615df117c1679b0d50d53c45f9f7e116e556a8315ee84857992e2abdd"
-    manifest_hash = default_manifest_hash
-
-    if manifest == "ambient_display_manifest.json":
-        manifest_hash = ambient_display_manifest_hash
 
     # check to see if user ran with sudo , since it's required
 
@@ -269,9 +261,6 @@ def main():
     print manifest_url
     print manifest_file
     downloader(manifest_url, manifest_file)
-
-    # check the hash of the incoming manifest file and bail if the hash doesn't match.
-    hash_file(manifest_file, manifest_hash)
 
     print "\n***** DINOBUILDR IS BUILDING. RAWR. *****\n"
     print "Building against the [%s] branch and the %s manifest\n" % (branch, manifest)


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1592852#c18, a bug was identified in the DMG processor, causing .app installers to be copied into the Applications directory without recursively changing ownership of all the files in the .app bundle to the logged in user. Since we run dinobuildr with sudo, any file in the .app bundle was owned by root - which causes the Firefox updater to prompt the user instead of silently installing updates, which is not ideal. 

We also stop changing the permissions on files in the .app installer, since this should not be required. Finally, we set the group ownership of anything installed inside the.app installer to `admin` since the user is likely going to be in the admin group. This isn't a great assumption, and in a perfect world we would determine if the logged in user is part of the administrators group, but it's a safer assumption than assigning everything to the `staff` group as we were doing previously and better emulates a user clicking and dragging a .app to Applications. 

We also removed the hash check for the manifest file. While this may seem like a security regression, since dino_engine.py and the manifest file are both hosted in Github, the value of the hash check is minimal. We're already trusting the validity of the files in Github, and if an attacker had the opportunity to mess with the manifest file, they have the opportunity to mess with dino_engine.py and subvert the entire hash checking function. 

At a later time, if we start to sign and hash-pin the bootstrap script, we can revisit hashing the manifest, but for now this removes a cumbersome step. 