### PR TITLE
Add Matrix bookmark to /resources/firefox-bookmarks.sh in branch:wallpaper-catalina

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -246,7 +246,7 @@ def main():
     raw_url = "https://raw.githubusercontent.com/%s/%s/%s/" % (org, repo, branch)
     manifest_url = "https://raw.githubusercontent.com/%s/%s/%s/%s" % (org, repo, branch, manifest)
     manifest_file = "%s/%s" % (local_dir, manifest)
-    default_manifest_hash = "17a8a13fddb6f9c086cdb36e7d7cf5e8262b206c6679545d4f2a5f852addc9d2"
+    default_manifest_hash = "7ba9058ebb004cebce519201b523cceb5ce8bf47cd8b256170c35b7cce019d38"
     ambient_display_manifest_hash = \
         "7fd9fe4615df117c1679b0d50d53c45f9f7e116e556a8315ee84857992e2abdd"
     manifest_hash = default_manifest_hash

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -97,7 +97,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "17a8a13fddb6f9c086cdb36e7d7cf5e8262b206c6679545d4f2a5f852addc9d2",
+            "hash": "2347eda6857d94e01b62c5158cf626da038109dce50e5e1268e40c6d3422e5a5",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -97,7 +97,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "732c3f94f42984ed30c49bd1cd01f950b9aef0fbb189d08ea88b7f20726683ee",
+            "hash": "17a8a13fddb6f9c086cdb36e7d7cf5e8262b206c6679545d4f2a5f852addc9d2",
             "type": "shell"
         },
         {

--- a/resources/firefox-bookmarks.sh
+++ b/resources/firefox-bookmarks.sh
@@ -53,8 +53,8 @@ cat > /Applications/Firefox.app/Contents/Resources/distribution/policies.json <<
         "Placement": "toolbar"
       },
       {
-        "Title": "IRCCloud",
-        "URL": "https://irccloud.mozilla.com",
+        "Title": "Matrix",
+        "URL": "https://chat.mozilla.org",
         "Placement": "toolbar"
       },
       {


### PR DESCRIPTION
Riot Matrix has replaced IRC Cloud as Mozilla's public messaging platform, so I've updated firefox-bookmarks.sh to reflect that. The hash has been updated in production_manifest.json (commit [3e1489a](https://github.com/mozilla/dinobuildr/commit/3e1489ae3b38431e3aa745d80c2297a57bef9d8e)) and in firefox-bookmarks.sh (commit [8613269](https://github.com/mozilla/dinobuildr/commit/86132698e0608984f2b5c167c6fe53019ba95eea))