### PR TITLE
update Crashplan to 8.0.0

### DIFF
--- a/production_manifest.json
+++ b/production_manifest.json
@@ -72,12 +72,12 @@
         },
         {
             "item": "Install Crashplan",
-            "version": "7.0.0",
-            "url": "https://download.code42.com/installs/mac/install/Code42CrashPlan/Code42CrashPlan_${version}_Mac.dmg",
+            "version": "",
+            "url": "https://download.code42.com/installs/agent/cloud/8.0.0/778/install/Code42CrashPlan_8.0.0_1525200006800_778_Mac.dmg",
             "filename": "",
             "dmg-installer": "Install Code42 CrashPlan.pkg",
             "dmg-advanced": "",
-            "hash": "a9de994edd0dc3bcc22564d91edbb153054b29a76904f2464ec9616d22d1c434",
+            "hash": "78430844a457482442328193c5b7c1ff8373668c2ec7b93c68942897d44b7f55",
             "type": "dmg"
         },
         {


### PR DESCRIPTION
update Crashplan to 8.0.0, use direct download link (from our internal documentation); update file hash for dmg installer

This time I tested on virtualbox vm (10.15.5) and a freshly erased/reinstalled macbook pro 16" and checks out fine/works with install.

Thanks!