### PR TITLE
update zoom to 5.1.2

### DIFF
--- a/production_manifest.json
+++ b/production_manifest.json
@@ -112,12 +112,12 @@
         },
         {
             "item": "Install Zoom",
-            "version": "4.4.53932.0709",
+            "version": "5.1.28648.0705",
             "url": "https://zoom.us/client/${version}/ZoomInstallerIT.pkg",
             "filename": "ZoomInstallerIT.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "68bb730f32a3f98286381d9299cec9d5dd37657128ca1750375942143e71ef49",
+            "hash": "95049593459a516e9751d589383700be63ed292e395ff0167cb5a908ec0e12e8",
             "type": "pkg"
         },
         {


### PR DESCRIPTION
update zoom to more recent version.

I ran the change by freshness in AVops and freshness agrees with updating zoom in our images to a recent zoom (5.1.2, 5.1.28648.0705 being the latest one)

tested in a virtualbox vm (10.15.5) and on a macbook pro 16" (10.15.6), installed cleanly and able to start zoom calls.