### PR TITLE
feature autohash-firefox - implements #184

### DIFF
--- a/dino_engine.py
+++ b/dino_engine.py
@@ -138,6 +138,7 @@ def mobileconfig_install(mobileconfig):
         print stderr
         exit(1)
 
+
 # autohash-firefox helper functions
 # checks given hash summary page for the line that matches given locale and returns hash
 def autohash_firefox_find_hash(hash_summary, locale):
@@ -154,11 +155,13 @@ def autohash_firefox_find_hash(hash_summary, locale):
 
 def autohash_firefox():
     # find latest firefox version by following redirect
-    response = urllib2.urlopen('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US')
+    response = urllib2.urlopen(
+        'https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US')
     version = urllib2.urlparse.urlsplit(response.geturl()).path.split('/')[-4]
     # build url to fetch official SHA256SUMS page
-    firefox_hash_url = "https://releases.mozilla.org/pub/firefox/releases/%s/SHA256SUMS" %version
-    print "NOTICE: Manifest file is instructing us to compare against official hash for Firefox version %s found at %s." % (version,firefox_hash_url)
+    firefox_hash_url = "https://releases.mozilla.org/pub/firefox/releases/%s/SHA256SUMS" % version
+    print ("NOTICE: Manifest file is instructing us to compare against official hash for "
+           "Firefox %s found at %s." % (version, firefox_hash_url))
     req = urllib2.Request(firefox_hash_url)
     response = urllib2.urlopen(req)
     hash_summary = response.read()

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -154,6 +154,25 @@ def hash_file(filename, man_hash):
         else:
             print "WARNING: The the hash for %s is unexpected." % filename
             exit(1)
+            
+            
+   # function that takes in the hash html file and checks for the line with the mac-us firefox SHA256 hash and returns the hash
+ def check_string_contains(textfile, strline): 
+    for line in textfile:
+        if strline in line:
+            linesplit = line.split()
+            hash = linesplit[0]
+            return hash
+    return False
+
+ 
+  # downloads the release SHA256 html page so I can use that file to search for the hash
+  def hashpage(url):
+    import urllib
+    url = 'http://releases.mozilla.org/pub/firefox/releases/77.0.1/SHA256SUMS'
+    urllib.urlretrieve(url, filename='hash.html')
+    file = open("hash.html", "r") 
+    return file
 
 
 # the pointer_to_json function accepts the url of the file in the github repo

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -149,6 +149,7 @@ def autohash_firefox_find_hash(hash_summary, locale):
             return hash
     return False
 
+
 def autohash_firefox():
     # find latest firefox version by following redirect
     response = urllib2.urlopen('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US')
@@ -162,6 +163,7 @@ def autohash_firefox():
     # find the hash for given locale
     hash = autohash_firefox_find_hash(hash_summary, "mac/en-US")
     return hash
+
 
 # the hash_file function accepts two arguments: the filename that you need to
 # determine the SHA256 hash of and the expected hash it returns True or False.
@@ -188,6 +190,7 @@ def hash_file(filename, man_hash):
         else:
             print "WARNING: The the hash for %s is unexpected." % filename
             exit(1)
+
 
 # the pointer_to_json function accepts the url of the file in the github repo
 # and the password to the repo. the pointer file is read from github then

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -138,12 +138,46 @@ def mobileconfig_install(mobileconfig):
         print stderr
         exit(1)
 
+# autohash-firefox helper functions
+# checks given hash summary page for the line that matches given locale and returns hash
+def autohash_firefox_find_hash(hash_summary, locale):
+    for line in hash_summary.split("\n"):
+        if locale in line:
+            linesplit = line.split()
+            # starting with 79.0 hashes are encoded in b'' form which might need decoding
+            hash = linesplit[0]
+            return hash
+    return False
+
+def autohash_firefox():
+    # find latest firefox version by following redirect
+    response = urllib2.urlopen('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang=en-US')
+    version = urllib2.urlparse.urlsplit(response.geturl()).path.split('/')[-4]
+    # build url to fetch official SHA256SUMS page
+    firefox_hash_url = "https://releases.mozilla.org/pub/firefox/releases/%s/SHA256SUMS" %version
+    print "NOTICE: Manifest file is instructing us to compare against official hash for Firefox version %s found at %s." % (version,firefox_hash_url)
+    req = urllib2.Request(firefox_hash_url)
+    response = urllib2.urlopen(req)
+    hash_summary = response.read()
+    # find the hash for given locale
+    hash = autohash_firefox_find_hash(hash_summary, "mac/en-US")
+    return hash
 
 # the hash_file function accepts two arguments: the filename that you need to
 # determine the SHA256 hash of and the expected hash it returns True or False.
 def hash_file(filename, man_hash):
     if man_hash == "skip":
         print "NOTICE: Manifest file is instructing us to SKIP hashing %s." % filename
+    elif man_hash == "autohash-firefox":
+        hash_check = hashlib.sha256()
+        with open(filename, 'rb') as downloaded_file:
+            for chunk in iter(lambda: downloaded_file.read(4096), b""):
+                hash_check.update(chunk)
+        if hash_check.hexdigest() == autohash_firefox():
+            print "\rThe hash for %s matches the official Firefox hash" % filename
+        else:
+            print "WARNING: The the hash for %s is unexpected." % filename
+            exit(1)
     else:
         hash_check = hashlib.sha256()
         with open(filename, 'rb') as downloaded_file:
@@ -154,26 +188,6 @@ def hash_file(filename, man_hash):
         else:
             print "WARNING: The the hash for %s is unexpected." % filename
             exit(1)
-            
-            
-   # function that takes in the hash html file and checks for the line with the mac-us firefox SHA256 hash and returns the hash
- def check_string_contains(textfile, strline): 
-    for line in textfile:
-        if strline in line:
-            linesplit = line.split()
-            hash = linesplit[0]
-            return hash
-    return False
-
- 
-  # downloads the release SHA256 html page so I can use that file to search for the hash
-  def hashpage(url):
-    import urllib
-    url = 'http://releases.mozilla.org/pub/firefox/releases/77.0.1/SHA256SUMS'
-    urllib.urlretrieve(url, filename='hash.html')
-    file = open("hash.html", "r") 
-    return file
-
 
 # the pointer_to_json function accepts the url of the file in the github repo
 # and the password to the repo. the pointer file is read from github then

--- a/dino_engine.py
+++ b/dino_engine.py
@@ -144,8 +144,10 @@ def autohash_firefox_find_hash(hash_summary, locale):
     for line in hash_summary.split("\n"):
         if locale in line:
             linesplit = line.split()
-            # starting with 79.0 hashes are encoded in b'' form which might need decoding
-            hash = linesplit[0]
+            # starting with 79.0 hashes are encoded in b'' form.
+            # easiest way to interpret is to split it 2nd char to 66th char, since the text is
+            # literal, and not read as an encoded string
+            hash = linesplit[0][2:66]
             return hash
     return False
 

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -82,12 +82,12 @@
         },
         {
             "item": "Install Firefox",
-            "version": "68.0.1",
+            "version": "latest",
             "url": "https://download.mozilla.org/?product=firefox-${version}-SSL&os=osx&lang=en-US",
             "filename": "firefox.dmg",
             "dmg-installer": "Firefox.app",
             "dmg-advanced": "",
-            "hash": "35a2f791a1d3802d0b0b40e2d47e8b8db4cab79129333529db5f0de7b8e4f284",
+            "hash": "autohash-firefox",
             "type": "dmg"
         },
         {


### PR DESCRIPTION
Patch cowritten by @geraltofpython and @jlin that implements a new hash type "autohash-firefox" that allows the use of a "latest" version tag in the production manifest for Firefox in order to automatically hash against current version hashes provided by Mozilla.

This tracks dinobuildr to the current Firefox release without having to rehash manually.

Tested in Virtualbox with 10.15.5 and on a MBP16" with 10.15.6

Appreciate lots of testing before merging!