### PR TITLE
Feat bigsur merging

### DIFF
--- a/production_manifest.json
+++ b/production_manifest.json
@@ -27,7 +27,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "c70d130a074b94c69cd2263f6b69761559a0f807698ea35c5aed832620613df1",
+            "hash": "75237ecaaf94207643c89f99966faeb696d479630646e5a0fdc936d88b4baaec",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -102,12 +102,12 @@
         },
         {
             "item": "Install Slack",
-            "version": "4.12.0",
-            "url": "https://downloads.slack-edge.com/releases/macos/4.12.0/prod/x64/Slack-${version}-macOS.dmg",
+            "version": "4.12.2",
+            "url": "https://downloads.slack-edge.com/releases/macos/${version}/prod/x64/Slack-${version}-macOS.dmg",
             "filename": "slack.dmg",
             "dmg-installer": "Slack.app",
             "dmg-advanced": "",
-            "hash": "5990ec9106d0c8fb6eaaf6d845063bb254c9e80401d2aa5aac173988cd2e502f",
+            "hash": "c7f7d16a95b18bb9d39bb83e23a26d898d9225c327e227ff39ed78479fd8d461",
             "type": "dmg"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -7,7 +7,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "e844fcf24f1e4d48f1719dca1ac0d381052c9e27ad402ae181d0feeda55f459e",
+            "hash": "7355c55561dd358ea87ec9cec2fd5213d332195f7c759dcd182e63b9d75b5540",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -182,12 +182,12 @@
         },
         {
             "item": "Install Zoom",
-            "version": "5.4.59780.1220",
+            "version": "5.4.59931.0110",
             "url": "https://zoom.us/client/${version}/Zoom.pkg",
             "filename": "Zoom.pkg",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "0e04a9e719cdb595a07c8b95eb0a8d7b702dccca173fa7bee0ffb9500ffba28e",
+            "hash": "56ee2b60afbe3a949913843263871df26e080b2475b304185a0817d434c971f2",
             "type": "pkg"
         }
     ]

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -177,7 +177,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "444591b5f64b5280935bc8b3459778a63a106399080bf4dfb854f5fad2c60562",
+            "hash": "ce9ab785e5e6818c47c2371385668000c8b267d1bdc31ecbc28bf7f6a01583b9",
             "type": "shell"
         },
         {

--- a/resources/macos-versioncheck.sh
+++ b/resources/macos-versioncheck.sh
@@ -7,13 +7,15 @@
 # this script checks for a minimum OS version and is intended to halt the build
 # if the machine does not meet that minimum version
 
-# expected_os - OS family version
-# expected_major - expected major version (13 = High Sierra, etc)
-# expected_minor - expected minor version
+# minimum_os - OS family version
+# minimum_major - minimum major version (15 = Catalina)
+# minimum_minor - minimum minor version
 
-expected_os="10"
-expected_major="13"
-expected_minor="3"
+# minimum is Catalina 10.15.0
+
+minimum_os="10"
+minimum_major="15"
+minimum_minor="0"
 
 os_version=$(sw_vers -productVersion | awk -F '.' '{print $1}')
 major_version=$(sw_vers -productVersion | awk -F '.' '{print $2}')
@@ -23,10 +25,10 @@ if [[ "$minor_version" -eq '' ]]; then
     minor_version=0
 fi
 
-if ! [[ "$os_version" -ge "$expected_os" && "$major_version" -ge "$expected_major" ]]; then
-    if ! [[ "$major_version" -gt "$expected_major" ]]; then
+if ! [[ "$os_version" -ge "$minimum_os" ]]; then
+    if ! [[ "$os_version" -eq "$minimum_os" && "$major_version" -ge "$minimum_major" ]]; then
         echo "UPGRADE REQUIRED: You are running macOS ${os_version}.${major_version}.${minor_version}"
-        echo "We are expecting: ${expected_os}.${expected_major}.${expected_minor}"
+        echo "We are expecting at least: ${minimum_os}.${minimum_major}.${minimum_minor}"
         echo "The build will halt, please update macOS via the App Store and try again."
         exit 1
     fi

--- a/resources/update-macos.sh
+++ b/resources/update-macos.sh
@@ -10,5 +10,4 @@
 # then, simply grab all available updates and install. 
 
 echo "Checking for macOS updates, this might take a while, please be patient..."
-/usr/sbin/softwareupdate --suspend-background
 /usr/sbin/softwareupdate --install --all

--- a/resources/wallpaper.sh
+++ b/resources/wallpaper.sh
@@ -60,7 +60,16 @@ elif [[ "$os_version" -eq "10" && "$major_version" -eq "15" ]]; then
     HASH="a5fd5700616730f3db1af48bf380156a1897197108be359a3c7769b7a359d7c9" # change only after thorough testing
 
     if [ "$(echo "$WALLPAPER_SH" | shasum -a 256 | awk '{print $1}')" == $HASH ]; then #  if the hashes match then proceed
-        echo "We're on Catalina so we're going to use the Mojave way to set the wallpaper."
+        echo "We're on Catalina so we're going to use the Catalina way to set the wallpaper."
+        /bin/bash -c "$WALLPAPER_SH" -s "/Users/Shared/$WALLPAPER_FILENAME"
+    fi
+elif [[ "$os_version" -eq "11" ]]; then
+# temporarily use jlin's set-desktop.sh with merged big sur fixes from upstream
+    WALLPAPER_SH=$(curl -fsSL https://raw.githubusercontent.com/jlin/macos-desktop/b71242b3da465927dd751800a16baa052c657fec/set-desktop.sh)
+    HASH="adf9c6406023735915de76f98f5ddd00772e9fcb132597af563745c5a357d91f" # change only after thorough testing
+    echo "$WALLPAPER_SH" | shasum -a 256 | awk '{print $1}'
+    if [ "$(echo "$WALLPAPER_SH" | shasum -a 256 | awk '{print $1}')" == $HASH ]; then #  if the hashes match then proceed
+        echo "We're on Big Sur so we're going to try to use the Big Sur way to set the wallpaper."
         /bin/bash -c "$WALLPAPER_SH" -s "/Users/Shared/$WALLPAPER_FILENAME"
     fi       
 else 


### PR DESCRIPTION
Merging in initial Big Sur compatibility for Intel based macs

Tested on MacBook Pro 15" 2015 running Big Sur 11.2 beta
Tested on VirtualBox VM running Catalina 10.15.7 
Tested on M1 Macbook Air running 11.1 (not optimized, still installing Intel binaries)

All the programs installed still need Rosetta on the M1 mac, will need to update this in a future release, but for now, at least Dinobuildr runs on Big Sur and installs all updated software

brief summary of changes:
versioncheck - set minimum to 10.15, allow 11
wallpaper - merged in updates from upstream, temporarily using scripts from jlin's repo - will update in future
softwareupdate - remove deprecated suspend-background option.