### PR TITLE
Upd8 m1 rosetta2

### DIFF
--- a/production_manifest.json
+++ b/production_manifest.json
@@ -51,7 +51,7 @@
             "type": "shell"
         },
         {
-            "item": "Install Rosetta 2 for arm systems",
+            "item": "Install Rosetta 2 if on an arm system",
             "version": "",
             "url": "resources/install-rosetta2.sh",
             "filename": "",

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -57,7 +57,7 @@
             "filename": "",
             "dmg-installer": "",
             "dmg-advanced": "",
-            "hash": "b4ab2e355e7a61b2a9b87ef4cc4f5e35dc22861eb1b40319e5018af907766669",
+            "hash": "324ee98cadce9fc66448f053d43fc7b703ff84e0aec33ab94b6193acb33aeabd",
             "type": "shell"
         },
         {

--- a/production_manifest.json
+++ b/production_manifest.json
@@ -51,6 +51,16 @@
             "type": "shell"
         },
         {
+            "item": "Install Rosetta 2 for arm systems",
+            "version": "",
+            "url": "resources/install-rosetta2.sh",
+            "filename": "",
+            "dmg-installer": "",
+            "dmg-advanced": "",
+            "hash": "b4ab2e355e7a61b2a9b87ef4cc4f5e35dc22861eb1b40319e5018af907766669",
+            "type": "shell"
+        },
+        {
             "item": "Download Crashplan deploy.properties",
             "version": "",
             "url": "resources/deploy.properties",

--- a/resources/install-rosetta2.sh
+++ b/resources/install-rosetta2.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# this script checks for machine processor architecture and
+# installs rosetta 2 for arm systems
+
+processor_architecture=$(uname -p)
+if [[ "$processor_architecture" = 'arm' ]]; then
+    echo "Installing Rosetta 2 for Arm system"
+    /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+    exit 0
+fi

--- a/resources/install-rosetta2.sh
+++ b/resources/install-rosetta2.sh
@@ -12,4 +12,7 @@ if [[ "$processor_architecture" = 'arm' ]]; then
     echo "Installing Rosetta 2 for Arm system"
     /usr/sbin/softwareupdate --install-rosetta --agree-to-license
     exit 0
+else
+    echo "You are using the ${processor_architecture} architecture, Rosetta not needed."
+    exit 0
 fi


### PR DESCRIPTION
Check for arm (via uname -p) and install rosetta 2 if found

Tested on M1 - rosetta installed as it should
Tested on Intel Mac Big Sur - no op as expected
Tested on Intel VM Catalina - no op as expected

refined the messaging a bit so it's clear that there's a test, and rosetta installation is depending on the platform